### PR TITLE
🐛[fix/#36] 테이블명 like에서 user_post로 변경

### DIFF
--- a/src/main/java/com/vinny/backend/post/domain/Like.java
+++ b/src/main/java/com/vinny/backend/post/domain/Like.java
@@ -8,7 +8,7 @@ import com.vinny.backend.User.domain.User;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "like")
+@Table(name = "user_post") //like는 예약어라서 변경
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #36 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
like가 sql예약어라 user_post로 테이블명 변경

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 테이블명 user_post로 변경
-

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
도메인 클래스 이름은 그대로 Like로 두는 것이 직관적인 면에서 낫다고 생각해서 테이블명만 변경하였습니다.
혹시 나중에 더 헷갈릴까요?

