### PR TITLE
🔧 [Chore] CI/CD build 오류 개선 및 docker-compose 수정

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,79 +1,55 @@
-name: Vinny Docker CI/CD Pipeline
+name: CI/CD to EC2
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   workflow_dispatch:
 
+env:
+  ECR_REGISTRY: 912394945783.dkr.ecr.ap-northeast-2.amazonaws.com
+  ECR_REPOSITORY: vinny-project
+  IMAGE_TAG: latest
+  AWS_REGION: ap-northeast-2
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Make application.yml  # application.yml 파일 생성 (운영용)
-        run: |
-          echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
-        shell: bash
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker image
-        run: |
-          docker build -t vinny:latest .
-
-      - name: Save Docker image as tar
-        run: docker save vinny:latest -o vinny-latest.tar
-
-      - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: vinny-image
-          path: vinny-latest.tar
-
   deploy:
-    needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - name: Download Docker image artifact
-        uses: actions/download-artifact@v4
+      - name: ✅ Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🔐 Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          name: vinny-image
-          path: .
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
-      - name: Deploy to EC2 without DockerHub
-        env:
-          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
-          EC2_USERNAME: ${{ secrets.EC2_USERNAME }}
-          EC2_HOST: ${{ secrets.EC2_HOST }}
+      - name: 🐳 Login to Amazon ECR
         run: |
-          echo "$EC2_SSH_KEY" > private_key.pem
-          chmod 600 private_key.pem
+          aws ecr get-login-password --region $AWS_REGION \
+          | docker login --username AWS --password-stdin $ECR_REGISTRY
 
-          # Docker image tar 전송
-          scp -i private_key.pem -o StrictHostKeyChecking=no vinny-latest.tar $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/
+      - name: 📦 Build and Push Docker image
+        run: |
+          docker build -t $ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-          # EC2에서 docker load + compose 실행
-          ssh -i private_key.pem -o StrictHostKeyChecking=no $EC2_USERNAME@$EC2_HOST "
-            set -ex
-            echo 'Step 1: cd ~/Vinny-backend'
-            cd ~/Vinny-backend
-          
-            echo 'Step 2: sudo docker compose down'
-            sudo docker compose down
-          
-            echo 'Step 3: sudo docker load'
-            sudo docker load -i ~/vinny-latest.tar
-          
-            echo 'Step 4: sudo docker compose up -d'
-            sudo docker compose up -d
-          
-            echo 'Step 5: done'
-          "
-
-
-
-          rm -f private_key.pem
+      - name: 🚀 Deploy to EC2 via SSH
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            docker stop vinny-app || true
+            docker rm vinny-app || true
+            docker run -d --restart always \
+              --name vinny-app \
+              --env-file /home/ubuntu/.env \
+              -p 8080:8080 \
+              $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,10 @@
-version: '3.8'
-
+version: "3.8"
 services:
-  springboot-app:
-    image: vinny:latest
+  app:
+    image: 912394945783.dkr.ecr.ap-northeast-2.amazonaws.com/vinny-backend:latest
+    container_name: vinny-app
+    restart: always
     ports:
       - "8080:8080"
-    environment:
-      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
-      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME}
-      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
-      SPRING_REDIS_HOST: redis
-      SPRING_REDIS_PORT: 6379
-    depends_on:
-      - redis
-
-  redis:
-    image: redis:7
-    container_name: my-redis
-    ports:
-      - "6379:6379"
+    env_file:
+      - .env


### PR DESCRIPTION

## 📌 연관 이슈
- close #81 

## 🌱 PR 요약
GitHub Actions를 이용해 EC2로의 자동 배포가 가능한 CI/CD 파이프라인을 구축했습니다.  
코드 push 시 ECR로 이미지가 푸시되고, EC2에서 최신 이미지를 pull하여 컨테이너를 재실행합니다.

## 🛠 작업 내용
- GitHub Actions 워크플로우 (`.github/workflows/deploy.yml`) 작성
- ECR에 Docker 이미지 자동 푸시
- EC2 SSH 접속 후 컨테이너 자동 재배포
- `.env` 파일을 활용한 환경변수 주입 처리
- `workflow_dispatch` 추가로 수동 배포 트리거 가능

## ❗️리뷰어들께
- GitHub Secrets에 필요한 값(AWS 키, EC2 SSH 키 등)이 잘 등록되어 있는지 확인해 주세요.
- EC2 인스턴스가 재시작돼도 컨테이너가 자동으로 실행되도록 `--restart always` 옵션 적용했습니다.
- 추후 무중단 배포나 docker-compose 도입도 고려할 수 있습니다.
