### PR TITLE
✨ [feat] @CurrentUser 어노테이션을 통한 사용자 ID 자동 주입 기능 추가

### DIFF
--- a/src/main/java/com/vinny/backend/auth/annotation/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/vinny/backend/auth/annotation/CurrentUserArgumentResolver.java
@@ -1,0 +1,42 @@
+package com.vinny.backend.auth.annotation;
+
+import com.vinny.backend.auth.jwt.JwtProvider;
+import com.vinny.backend.search.annotation.CurrentUser;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    public CurrentUserArgumentResolver(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && parameter.getParameterType().equals(Long.class); // userId 타입
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        String token = jwtProvider.resolveToken(request); // Header에서 Bearer 토큰 추출
+        if (token == null || !jwtProvider.validateToken(token)) {
+            throw new RuntimeException("유효하지 않은 토큰입니다.");
+        }
+
+        return jwtProvider.getUserIdFromToken(token); // 실제 userId 추출
+    }
+}
+

--- a/src/main/java/com/vinny/backend/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/vinny/backend/auth/jwt/JwtProvider.java
@@ -5,6 +5,7 @@ import com.vinny.backend.auth.dto.TokenDto;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -12,6 +13,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.util.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -100,4 +102,23 @@ public class JwtProvider {
             return e.getClaims();
         }
     }
+
+    /*
+    jwt 토큰에서 userid 추출하는 매서드
+    @CurrentUser 어노테이션으로 별다른 구조 없이 사용자 userId 추출해서 사용가능
+     */
+    public Long getUserIdFromToken(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        return Long.parseLong(claims.getSubject()); // subject에 kakaoUserId를 넣었기 때문에
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+
 }

--- a/src/main/java/com/vinny/backend/config/WebConfig.java
+++ b/src/main/java/com/vinny/backend/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.vinny.backend.config;
+
+import com.vinny.backend.auth.annotation.CurrentUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    public WebConfig(CurrentUserArgumentResolver resolver) {
+        this.currentUserArgumentResolver = resolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/vinny/backend/search/annotation/CurrentUser.java
+++ b/src/main/java/com/vinny/backend/search/annotation/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.vinny.backend.search.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Feat/#89] @CurrentUser 어노테이션을 통한 로그인 사용자 식별 기능 추가 -->

## 📌 연관 이슈  
- close #89

## 🌱 PR 요약  
스웨거 테스트 및 서비스 실행 시 필요한 `@CurrentUser` 어노테이션 구현

## 🛠 작업 내용  
- `@CurrentUser` 어노테이션 정의  
- `CurrentUserArgumentResolver` 구현  
- `WebMvcConfigurer`를 통해 Resolver 등록 (`addArgumentResolvers`)  
-  해당 JWT 토큰에서 사용자 id를 추출하여 파라미터에 별도의 코드 없이 적용 가능하도록 처리  
- <img width="528" height="22" alt="image" src="https://github.com/user-attachments/assets/74df97bc-0714-4a9a-b53b-6a28bef54459" />  Controller에서 이런 식으로 구현하면 바로 사용 가능

## ❗️ 리뷰어들께  
- 컨트롤러에서 `@CurrentUser Long userId`가 잘 주입되는지 확인 부탁드립니다.  
- `JwtTokenProvider`의 `getUserIdFromToken()`이 Long 타입의 userId를 반환해야 합니다.  
- 토큰 subject에 id가 userId로 변경된다면, 메서드가 `findByKakaoId()`에서 `findById()`로 수정 가능합니다.  

