### PR TITLE
✨ [feat] 최근 검색어 추가 api 설계

### DIFF
--- a/src/main/java/com/vinny/backend/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/vinny/backend/error/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 멤버 관려 에러
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
 
     // 예시,,,
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),

--- a/src/main/java/com/vinny/backend/search/controller/SearchLogController.java
+++ b/src/main/java/com/vinny/backend/search/controller/SearchLogController.java
@@ -1,0 +1,42 @@
+package com.vinny.backend.search.controller;
+
+import com.vinny.backend.error.ApiResponse;
+import com.vinny.backend.search.annotation.CurrentUser;
+import com.vinny.backend.search.dto.SearchLogCreateRequest;
+import com.vinny.backend.search.dto.SearchLogResponse;
+import com.vinny.backend.search.service.SearchLogService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/search-logs")
+@RequiredArgsConstructor
+@Tag(name = "SearchLog", description = "검색 로그 관리 API")
+public class SearchLogController {
+
+    private final SearchLogService searchLogService;
+
+    @Operation(summary = "검색어 추가", description = "사용자의 검색어를 저장합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색어 저장 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<SearchLogResponse>> addSearchLog(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @Valid @RequestBody SearchLogCreateRequest request) {
+
+        SearchLogResponse response = searchLogService.addSearchLog(userId, request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+}

--- a/src/main/java/com/vinny/backend/search/dto/SearchLogCreateRequest.java
+++ b/src/main/java/com/vinny/backend/search/dto/SearchLogCreateRequest.java
@@ -1,0 +1,22 @@
+package com.vinny.backend.search.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "검색어 추가 요청")
+public class SearchLogCreateRequest {
+
+    @NotBlank(message = "검색어는 필수입니다.")
+    @Size(min = 1, max = 100, message = "검색어는 1자 이상 100자 이하여야 합니다.")
+    @Schema(description = "검색 키워드", example = "빈티지 자켓", required = true)
+    private String keyword;
+
+    public SearchLogCreateRequest(String keyword) {
+        this.keyword = keyword;
+    }
+}

--- a/src/main/java/com/vinny/backend/search/dto/SearchLogResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/SearchLogResponse.java
@@ -1,0 +1,27 @@
+package com.vinny.backend.search.dto;
+
+import com.vinny.backend.User.domain.SearchLog;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "검색어 응답")
+public record SearchLogResponse(
+        @Schema(description = "검색 로그 ID", example = "1")
+        Long id,
+
+        @Schema(description = "검색 키워드", example = "빈티지 자켓")
+        String keyword,
+
+        @Schema(description = "검색 시간", example = "2024-07-20T10:30:00")
+        LocalDateTime searchedAt
+) {
+
+    public static SearchLogResponse from(SearchLog searchLog) {
+        return new SearchLogResponse(
+                searchLog.getId(),
+                searchLog.getKeyword(),
+                searchLog.getSearchedAt()
+        );
+    }
+}

--- a/src/main/java/com/vinny/backend/search/repository/SearchLogRepository.java
+++ b/src/main/java/com/vinny/backend/search/repository/SearchLogRepository.java
@@ -1,0 +1,45 @@
+package com.vinny.backend.search.repository;
+
+import com.vinny.backend.User.domain.SearchLog;
+import com.vinny.backend.User.domain.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface SearchLogRepository extends JpaRepository<SearchLog, Long> {
+
+    /**
+     * 사용자의 특정 키워드 검색 로그 조회 (중복 체크용)
+     */
+    Optional<SearchLog> findByUserAndKeyword(User user, String keyword);
+
+    /**
+     * 사용자의 최근 검색어 목록 조회 (최신순)
+     */
+    @Query("SELECT s FROM SearchLog s WHERE s.user = :user ORDER BY s.searchedAt DESC")
+    List<SearchLog> findByUserOrderBySearchedAtDesc(@Param("user") User user, Pageable pageable);
+
+    /**
+     * 사용자의 검색 로그 개수 조회
+     */
+    long countByUser(User user);
+
+    /**
+     * 사용자의 오래된 검색 로그 삭제 (최대 개수 초과시)
+     */
+    @Modifying
+    @Query("DELETE FROM SearchLog s WHERE s.user = :user AND s.searchedAt < :cutoffTime")
+    void deleteOldSearchLogs(@Param("user") User user, @Param("cutoffTime") LocalDateTime cutoffTime);
+
+    /**
+     * 사용자의 가장 오래된 검색 로그들 조회
+     */
+    @Query("SELECT s FROM SearchLog s WHERE s.user = :user ORDER BY s.searchedAt ASC")
+    List<SearchLog> findOldestByUser(@Param("user") User user, Pageable pageable);
+}

--- a/src/main/java/com/vinny/backend/search/service/SearchLogService.java
+++ b/src/main/java/com/vinny/backend/search/service/SearchLogService.java
@@ -1,0 +1,117 @@
+package com.vinny.backend.search.service;
+
+import com.vinny.backend.User.domain.SearchLog;
+import com.vinny.backend.User.domain.User;
+import com.vinny.backend.User.repository.UserRepository;
+import com.vinny.backend.error.code.status.ErrorStatus;
+import com.vinny.backend.error.exception.GeneralException;
+import com.vinny.backend.search.dto.SearchLogCreateRequest;
+import com.vinny.backend.search.dto.SearchLogResponse;
+import com.vinny.backend.search.repository.SearchLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class SearchLogService {
+
+    private final SearchLogRepository searchLogRepository;
+    private final UserRepository userRepository;
+
+    // 최대 저장 가능한 검색어 개수
+    private static final int MAX_SEARCH_LOG_COUNT = 20;
+    // 조회할 최근 검색어 개수
+    private static final int RECENT_SEARCH_COUNT = 10;
+
+    /**
+     * 검색어 추가
+     * - 중복 검색어는 시간만 업데이트
+     * - 최대 개수 초과시 오래된 검색어 삭제
+     */
+    @Transactional
+    public SearchLogResponse addSearchLog(Long userId, SearchLogCreateRequest request) {
+        // 사용자 조회
+        User user = userRepository.findByKakaoUserId(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 키워드 정제 (앞뒤 공백 제거, 소문자 변환 등)
+        String normalizedKeyword = normalizeKeyword(request.getKeyword());
+
+        // 중복 검색어 확인
+        Optional<SearchLog> existingSearchLog = searchLogRepository
+                .findByUserAndKeyword(user, normalizedKeyword);
+
+        SearchLog searchLog;
+        if (existingSearchLog.isPresent()) {
+            // 기존 검색어가 있으면 시간만 업데이트
+            searchLog = updateExistingSearchLog(existingSearchLog.get());
+            log.info("Updated existing search log for user: {}, keyword: {}", userId, normalizedKeyword);
+        } else {
+            // 새로운 검색어 추가
+            searchLog = createNewSearchLog(user, normalizedKeyword);
+
+            // 최대 개수 체크 및 정리
+            cleanupOldSearchLogsIfNeeded(user);
+            log.info("Created new search log for user: {}, keyword: {}", userId, normalizedKeyword);
+        }
+
+        return SearchLogResponse.from(searchLog);
+    }
+
+    /**
+     * 키워드 정규화
+     */
+    private String normalizeKeyword(String keyword) {
+        return keyword.trim().toLowerCase();
+    }
+
+    @Transactional
+    public SearchLog updateExistingSearchLog(SearchLog existingSearchLog) {
+        // 엔티티에 setter 없이 시간 업데이트하는 방법
+        SearchLog updatedSearchLog = SearchLog.builder()
+                .id(existingSearchLog.getId())
+                .user(existingSearchLog.getUser())
+                .keyword(existingSearchLog.getKeyword())
+                .searchedAt(LocalDateTime.now()) // 현재 시간으로 업데이트
+                .build();
+
+        return searchLogRepository.save(updatedSearchLog);
+    }
+
+    /**
+     * 새로운 검색어 생성
+     */
+    private SearchLog createNewSearchLog(User user, String keyword) {
+        SearchLog searchLog = SearchLog.builder()
+                .user(user)
+                .keyword(keyword)
+                .build();
+
+        return searchLogRepository.save(searchLog);
+    }
+
+    /**
+     * 최대 개수 초과시 오래된 검색어 삭제
+     */
+    private void cleanupOldSearchLogsIfNeeded(User user) {
+        long currentCount = searchLogRepository.countByUser(user);
+
+        if (currentCount > MAX_SEARCH_LOG_COUNT) {
+            int deleteCount = (int) (currentCount - MAX_SEARCH_LOG_COUNT);
+            List<SearchLog> oldestLogs = searchLogRepository
+                    .findOldestByUser(user, PageRequest.of(0, deleteCount));
+
+            searchLogRepository.deleteAll(oldestLogs);
+            log.info("Cleaned up {} old search logs for user: {}", deleteCount, user.getId());
+        }
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Feat/#XX] 최근 검색어 추가 API 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요! -->

## 📌 연관 이슈
- close #73 

## 🌱 PR 요약
- 최근 검색어 추가(POST) API 설계 및 구현
- 중복 검색어 처리 및 입력값 검증, 예외 처리 로직 반영

## 🛠 작업 내용
- `/search-logs` 엔드포인트, `POST` 메서드로 검색어 추가 API 설계
- 동일 사용자의 기존 검색어와 중복 여부 판별 후,
    - 중복 시 최근 검색 시각만 갱신
    - 신규 검색어면 새 로그 추가
- 검색어 유효성(길이, 공백 등) 검증 및 예외 처리
- 잘못된 요청(빈 값, 유효하지 않은 토큰 등)시 적절한 예외 응답 반환
- JWT 토큰 기반 사용자 식별 적용
- test까지 확인되었습니다!
<img width="605" height="628" alt="image" src="https://github.com/user-attachments/assets/4a7a3e2e-a714-4124-a0f3-ab616cb17b44" />


## ❗️리뷰어들께
- 정상적인 JWT 토큰이 전달될 때, `@CurrentUser`가 잘 동작하는지 확인 바랍니다.
- 중복 검색어 처리(갱신/신규 추가) 로직이 요구사항에 부합하는지 검토 요청드립니다.
- Validation 실패 시 에러 응답 포맷도 체크 부탁드립니다.
- 추가적으로 검색이 따로 많이 필요할 거라 예상이되어 search directory를 따로 만들었습니다!

---

### 🙋🏻 참고 자료  

