### PR TITLE
 🐛[Fix/#99] 가게 후기 작성 api imageURL S3 설정

### DIFF
--- a/src/main/java/com/vinny/backend/Shop/controller/ReviewController.java
+++ b/src/main/java/com/vinny/backend/Shop/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.vinny.backend.Shop.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vinny.backend.Shop.dto.ReviewRequestDto;
 import com.vinny.backend.Shop.dto.ReviewResponseDto;
 import com.vinny.backend.Shop.service.ReviewService;
@@ -9,8 +10,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/shops")
@@ -20,14 +26,31 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    @PostMapping("/{shopId}/reviews")
-    @Operation(summary = "리뷰 생성", description = "지정된 샵에 리뷰를 작성합니다.")
-    public ResponseEntity<ReviewResponseDto.PreviewDto> createReview(
-            @PathVariable Long shopId,
-            @RequestBody ReviewRequestDto.CreateDto dto,
-            @CurrentUser Long userId
-    ) {
-        return ResponseEntity.ok(reviewService.createReview(dto, shopId, userId));
-    }
+//    @PostMapping(value = "/{shopId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+//    @Operation(summary = "리뷰 생성", description = "지정된 샵에 리뷰를 작성합니다. 이미지 파일도 함께 업로드합니다.")
+//    public ResponseEntity<ReviewResponseDto.PreviewDto> createReview(
+//            @PathVariable Long shopId,
+//            @RequestPart("dto") ReviewRequestDto.CreateDto dto, // JSON 본문
+//            @RequestPart(value = "images", required = false) List<MultipartFile> images, // 이미지 파일 리스트
+//            @CurrentUser Long userId
+//    ) throws IOException {
+//        ReviewResponseDto.PreviewDto result = reviewService.createReview(dto, shopId, userId, images);
+//        return ResponseEntity.ok(result);
+//    }
+        @PostMapping(value = "/{shopId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        @Operation(summary = "리뷰 생성", description = "지정된 샵에 리뷰를 작성합니다.")
+        public ResponseEntity<ReviewResponseDto.PreviewDto> createReview(
+                @PathVariable Long shopId,
+                @RequestPart("dto") String dtoJson,
+                @RequestPart(value = "images", required = false) List<MultipartFile> images,
+                @CurrentUser Long userId
+        ) throws IOException {
+
+            // JSON 문자열을 수동으로 객체로 변환
+            ObjectMapper objectMapper = new ObjectMapper();
+            ReviewRequestDto.CreateDto dto = objectMapper.readValue(dtoJson, ReviewRequestDto.CreateDto.class);
+
+            return ResponseEntity.ok(reviewService.createReview(dto, shopId, userId, images));
+        }
 
 }

--- a/src/main/java/com/vinny/backend/Shop/controller/ReviewController.java
+++ b/src/main/java/com/vinny/backend/Shop/controller/ReviewController.java
@@ -7,6 +7,8 @@ import com.vinny.backend.Shop.service.ReviewService;
 import com.vinny.backend.User.domain.User;
 import com.vinny.backend.search.annotation.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -26,31 +28,40 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-//    @PostMapping(value = "/{shopId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-//    @Operation(summary = "리뷰 생성", description = "지정된 샵에 리뷰를 작성합니다. 이미지 파일도 함께 업로드합니다.")
-//    public ResponseEntity<ReviewResponseDto.PreviewDto> createReview(
-//            @PathVariable Long shopId,
-//            @RequestPart("dto") ReviewRequestDto.CreateDto dto, // JSON 본문
-//            @RequestPart(value = "images", required = false) List<MultipartFile> images, // 이미지 파일 리스트
-//            @CurrentUser Long userId
-//    ) throws IOException {
-//        ReviewResponseDto.PreviewDto result = reviewService.createReview(dto, shopId, userId, images);
-//        return ResponseEntity.ok(result);
-//    }
+    /**
+    후기 작성 스웨거 용
+    **/
         @PostMapping(value = "/{shopId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        @Operation(summary = "리뷰 생성", description = "지정된 샵에 리뷰를 작성합니다.")
+        @Operation(summary = "후기 생성", description = "지정된 가게에 후기를 작성합니다.")
         public ResponseEntity<ReviewResponseDto.PreviewDto> createReview(
                 @PathVariable Long shopId,
+                @Parameter(
+                        name = "dto",
+                        description = "JSON 문자열 입력 예시:\n{\n  \"title\": \"리뷰 제목\",\n  \"content\": \"리뷰 내용\"\n}",
+                        required = true
+                )
                 @RequestPart("dto") String dtoJson,
-                @RequestPart(value = "images", required = false) List<MultipartFile> images,
-                @CurrentUser Long userId
+                @RequestPart(value = "images", required = false) List<MultipartFile> images
         ) throws IOException {
-
             // JSON 문자열을 수동으로 객체로 변환
             ObjectMapper objectMapper = new ObjectMapper();
             ReviewRequestDto.CreateDto dto = objectMapper.readValue(dtoJson, ReviewRequestDto.CreateDto.class);
 
-            return ResponseEntity.ok(reviewService.createReview(dto, shopId, userId, images));
+            return ResponseEntity.ok(reviewService.createReview(dto, shopId, images));
         }
+
+    /**
+     후기 작성 운영용
+     **/
+//        @PostMapping(value = "/{shopId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+//        @Operation(summary = "후기 생성", description = "지정된 가게에 후기를 작성합니다.")
+//        public ResponseEntity<ReviewResponseDto.PreviewDto> createReview(
+//                @PathVariable Long shopId,
+//                @RequestPart("dto") ReviewRequestDto.CreateDto dto,
+//                @RequestPart(value = "images", required = false) List<MultipartFile> images
+//        ) throws IOException {
+//            return ResponseEntity.ok(reviewService.createReview(dto, shopId, images));
+//        }
+
 
 }

--- a/src/main/java/com/vinny/backend/Shop/dto/ReviewRequestDto.java
+++ b/src/main/java/com/vinny/backend/Shop/dto/ReviewRequestDto.java
@@ -20,8 +20,5 @@ public class ReviewRequestDto {
 
         @NotBlank(message = "content는 비어있을 수 없습니다.")
         private String content;
-
-        @NotNull(message = "imageUrls는 null일 수 없습니다.")
-        private List<@NotBlank(message = "imageUrl는 비어있을 수 없습니다.") String> imageUrls;
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #99 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
기존의 가게 후기 작성 api ImageURL을 string으로 받았는데, S3에 업로드 후 링크를 받을 수 있게 변경하였습니다.
-7.26 수정-
userId를 파라미터로 입력받는 걸 빼고 인증처리하게 했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 서비스, 컨트롤러 변경
- 미디어 파일과 JSON DTO를 함께 파라미터로 받을 경우, Spring 자체는 문제없지만
Swagger UI나 일부 클라이언트 도구가 JSON DTO를 잘못된 Content-Type으로 보내면서 415 오류가 발생한다고 합니다.
그래서 스웨거 용, 운영용(주석처리)를 만들었습니다.

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
-7.26 수정-
<img width="1763" height="1883" alt="image" src="https://github.com/user-attachments/assets/8c632bf2-a4c8-4afd-8dd6-cd6fcf421438" />
<img width="1102" height="109" alt="image" src="https://github.com/user-attachments/assets/c1a95485-f767-47ec-9264-483df896ae1a" />
