### PR TITLE
✨[Feat/#94] 카테고리 아이콘 클릭시 해당 키워드 검색 api 기능 구현 

### DIFF
--- a/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
+++ b/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
@@ -30,7 +30,7 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
         JOIN s.shopVintageStyleList svs 
         JOIN svs.vintageStyle vs 
         WHERE vs.name = :styleName 
-        AND s.status = 'ACTIVE'
+        AND s.status = 'OPEN'
         """)
     Page<Shop> findByStyle(@Param("styleName") String styleType, Pageable pageable);
 
@@ -41,7 +41,7 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
         JOIN s.region r 
         WHERE vs.name = :styleName 
         AND r.name LIKE %:region% 
-        AND s.status = 'ACTIVE'
+        AND s.status = 'OPEN'
         """)
     Page<Shop> findByStyleAndRegion(
             @Param("styleName") String styleType,

--- a/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
+++ b/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
@@ -25,4 +25,27 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
 
     Page<Shop> findByShopVintageStyleList_VintageStyle_Name(String style, Pageable pageable);
 
+    @Query("""
+        SELECT DISTINCT s FROM Shop s 
+        JOIN s.shopVintageStyleList svs 
+        JOIN svs.vintageStyle vs 
+        WHERE vs.name = :styleName 
+        AND s.status = 'ACTIVE'
+        """)
+    Page<Shop> findByStyle(@Param("styleName") String styleType, Pageable pageable);
+
+    @Query("""
+        SELECT DISTINCT s FROM Shop s 
+        JOIN s.shopVintageStyleList svs 
+        JOIN svs.vintageStyle vs 
+        JOIN s.region r 
+        WHERE vs.name = :styleName 
+        AND r.name LIKE %:region% 
+        AND s.status = 'ACTIVE'
+        """)
+    Page<Shop> findByStyleAndRegion(
+            @Param("styleName") String styleType,
+            @Param("region") String region,
+            Pageable pageable);
+
 }

--- a/src/main/java/com/vinny/backend/error/ApiResponse.java
+++ b/src/main/java/com/vinny/backend/error/ApiResponse.java
@@ -27,6 +27,11 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
     }
 
+    public static <T> ApiResponse<T> onSuccess(String message, T result) {
+        return new ApiResponse<>(true,SuccessStatus._OK.getCode(), message, result);
+    }
+
+
     public static <T> ApiResponse<T> of(BaseCode code, T result){
             return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
     }

--- a/src/main/java/com/vinny/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/vinny/backend/post/repository/PostRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -32,4 +33,26 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "LEFT JOIN FETCH p.images i",
             countQuery = "SELECT COUNT(p) FROM Post p")
     Page<Post> findAllWithAssociations(Pageable pageable);
+
+    @Query("""
+        SELECT DISTINCT p FROM Post p 
+        JOIN p.styleHashtags sh 
+        JOIN sh.vintageStyle vs 
+        WHERE vs.name = :styleName
+        """)
+    Page<Post> findByStyle(@Param("styleName") String styleType, Pageable pageable);
+
+    @Query("""
+        SELECT DISTINCT p FROM Post p 
+        JOIN p.styleHashtags sh 
+        JOIN sh.vintageStyle vs 
+        WHERE vs.name = :styleName 
+        AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)
+        """)
+    Page<Post> findByStyleAndKeyword(
+            @Param("styleName") String styleType,
+            @Param("keyword") String keyword,
+            Pageable pageable);
 }
+
+

--- a/src/main/java/com/vinny/backend/search/controller/SearchController.java
+++ b/src/main/java/com/vinny/backend/search/controller/SearchController.java
@@ -1,0 +1,62 @@
+package com.vinny.backend.search.controller;
+
+import com.vinny.backend.error.ApiResponse;
+import com.vinny.backend.search.dto.PostResponse;
+import com.vinny.backend.search.dto.ShopResponse;
+import com.vinny.backend.search.dto.StyleSearchRequest;
+import com.vinny.backend.search.service.PostSearchService;
+import com.vinny.backend.search.service.ShopSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+@Tag(name = "Search", description = "스타일별 게시글/매장 검색 API")
+public class SearchController {
+
+    private final PostSearchService postSearchService;
+    private final ShopSearchService shopSearchService;
+
+    // ========== POST 검색 ==========
+    @Operation(summary = "스타일별 게시물 검색", description = "스타일 타입/키워드/지역 등으로 게시물을 검색합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @PostMapping("/posts/style")
+    public ResponseEntity<ApiResponse<Page<PostResponse>>> searchPostsByStyle(
+            @Valid @RequestBody StyleSearchRequest request,
+            @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+
+        Page<PostResponse> results = postSearchService.searchByStyle(request, pageable);
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                request.styleType() + " 스타일 게시물 검색 완료", results));
+    }
+
+
+    // ========== SHOP 검색 ==========
+    @Operation(summary = "스타일별 매장 검색", description = "스타일 타입/키워드/지역 등으로 매장을 검색합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @PostMapping("/shops/style")
+    public ResponseEntity<ApiResponse<Page<ShopResponse>>> searchShopsByStyle(
+            @Valid @RequestBody StyleSearchRequest request,
+            @Parameter(hidden = true) @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+
+        Page<ShopResponse> results = shopSearchService.searchByStyle(request, pageable);
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                request.styleType() + " 스타일 매장 검색 완료", results));
+    }
+}

--- a/src/main/java/com/vinny/backend/search/dto/PostResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/PostResponse.java
@@ -1,0 +1,19 @@
+package com.vinny.backend.search.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record PostResponse(
+        Long id,
+        String title,
+        String content,
+        UserSearchResponse author,
+        List<String> images,
+        List<String> styles,
+        LocalDateTime createdAt,
+        Integer totalImageCount,
+        Integer likeCount
+) {}

--- a/src/main/java/com/vinny/backend/search/dto/ShopResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/ShopResponse.java
@@ -1,0 +1,17 @@
+package com.vinny.backend.search.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ShopResponse(
+        Long id,
+        String name,
+        String address,
+        String addressDetail,
+        String region,
+        List<String> styles,
+        String imageUrl,
+        String status
+) {}

--- a/src/main/java/com/vinny/backend/search/dto/StyleSearchRequest.java
+++ b/src/main/java/com/vinny/backend/search/dto/StyleSearchRequest.java
@@ -1,0 +1,17 @@
+package com.vinny.backend.search.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "스타일 검색 요청 DTO")
+public record StyleSearchRequest(
+        @Schema(description = "스타일 타입", example = "VINTAGE")
+        @NotNull(message = "스타일은 필수입니다.")
+        String styleType,
+
+        @Schema(description = "검색 키워드", example = "자켓")
+        String keyword,
+
+        @Schema(description = "지역명", example = "서울")
+        String region
+) {}

--- a/src/main/java/com/vinny/backend/search/dto/UserSearchResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/UserSearchResponse.java
@@ -1,0 +1,21 @@
+package com.vinny.backend.search.dto;
+
+import lombok.Builder;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 검색 결과 응답 DTO")
+@Builder
+public record UserSearchResponse(
+        @Schema(description = "유저 ID", example = "123")
+        Long id,
+
+        @Schema(description = "닉네임", example = "vinny_dev")
+        String nickname,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://cdn.vinny.com/images/profile.png")
+        String profileImage,
+
+        @Schema(description = "한줄 소개/코멘트", example = "빈티지 스타일을 좋아합니다!")
+        String comment
+) {}

--- a/src/main/java/com/vinny/backend/search/service/PostSearchService.java
+++ b/src/main/java/com/vinny/backend/search/service/PostSearchService.java
@@ -1,0 +1,68 @@
+package com.vinny.backend.search.service;
+
+import com.vinny.backend.post.domain.Post;
+import com.vinny.backend.post.repository.PostRepository;
+import com.vinny.backend.search.dto.PostResponse;
+import com.vinny.backend.search.dto.StyleSearchRequest;
+import com.vinny.backend.search.dto.UserSearchResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class PostSearchService {
+
+    private final PostRepository postRepository;
+
+    public Page<PostResponse> searchByStyle(StyleSearchRequest request, Pageable pageable) {
+        Page<Post> posts;
+
+        if (request.keyword() != null && !request.keyword().trim().isEmpty()) {
+            posts = postRepository.findByStyleAndKeyword(
+                    request.styleType(), request.keyword(), pageable);
+        } else {
+            posts = postRepository.findByStyle(request.styleType(), pageable);
+        }
+
+        return posts.map(this::convertToResponse);
+    }
+
+
+    private PostResponse convertToResponse(Post post) {
+        // User 정보를 UserSearchResponse로 변환
+        UserSearchResponse author = UserSearchResponse.builder()
+                .id(post.getUser().getId())
+                .nickname(post.getUser().getNickname())
+                .profileImage(post.getUser().getProfileImage())
+                .comment(post.getUser().getComment())
+                .build();
+
+        // 이미지 URL 리스트
+        List<String> imageUrls = post.getImages().stream()
+                .map(img -> img.getImageUrl())
+                .collect(Collectors.toList());
+
+        return PostResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .author(author)
+                .images(imageUrls)
+                .styles(post.getStyleHashtags().stream()
+                        .map(hashtag -> hashtag.getVintageStyle().getName())
+                        .collect(Collectors.toList()))
+                .createdAt(post.getCreatedAt())
+                .totalImageCount(imageUrls.size())
+                .likeCount(post.getLikes().size())
+                .build();
+    }
+}

--- a/src/main/java/com/vinny/backend/search/service/ShopSearchService.java
+++ b/src/main/java/com/vinny/backend/search/service/ShopSearchService.java
@@ -1,0 +1,50 @@
+package com.vinny.backend.search.service;
+
+
+import com.vinny.backend.Shop.domain.Shop;
+import com.vinny.backend.Shop.repository.ShopRepository;
+import com.vinny.backend.search.dto.ShopResponse;
+import com.vinny.backend.search.dto.StyleSearchRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShopSearchService {
+
+    private final ShopRepository shopRepository;
+
+    public Page<ShopResponse> searchByStyle(StyleSearchRequest request, Pageable pageable) {
+        Page<Shop> shops;
+
+        if (request.region() != null && !request.region().trim().isEmpty()) {
+            shops = shopRepository.findByStyleAndRegion(
+                    request.styleType(), request.region(), pageable);
+        } else {
+            shops = shopRepository.findByStyle(request.styleType(), pageable);
+        }
+
+        return shops.map(this::convertToResponse);
+    }
+
+    private ShopResponse convertToResponse(Shop shop) {
+        return ShopResponse.builder()
+                .id(shop.getId())
+                .name(shop.getName())
+                .address(shop.getAddress())
+                .addressDetail(shop.getAddressDetail())
+                .region(shop.getRegion() != null ? shop.getRegion().getName() : null)
+                .styles(shop.getShopVintageStyleList().stream()
+                        .map(style -> style.getVintageStyle().getName())
+                        .collect(Collectors.toList()))
+                .imageUrl(shop.getShopImages().isEmpty() ? null : shop.getShopImages().get(0).getImageUrl())
+                .status(shop.getStatus().name())
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #94 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 사용자가 스타일 카테고리(밀리터리, 아메카지, 스트릿 등)를 선택하여 관련 게시물과 매장을 검색할 수 있는 기능을 구현했습니다.
통합 SearchController를 통해 일관된 검색 경험을 제공하며, 키워드 및 지역 필터링도 지원합니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 키워드 검색: 제목/내용에 키워드 포함된 게시물 검색
- 페이징 처리: Spring Data JPA Pageable 지원
<img width="100%" height="496" alt="image" src="https://github.com/user-attachments/assets/8dd429dd-b825-443d-b6e7-d5009dc6f56c" />


<img width="100%" height="547" alt="image" src="https://github.com/user-attachments/assets/870c1436-9aa9-458c-a20c-4019bd6b8452" />


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
- Controller 설계: Post/Shop을 분리하지 않고 SearchController로 통합한 설계가 적절한가?
- 페이징: 기본 20개씩, createdAt 내림차순 정렬로 설정했습니다