### PR TITLE
✨[Feat/#105] 최근 검색어 조회 api 구현 

### DIFF
--- a/src/main/java/com/vinny/backend/User/domain/User.java
+++ b/src/main/java/com/vinny/backend/User/domain/User.java
@@ -4,6 +4,7 @@ import com.vinny.backend.User.domain.enums.Provider;
 import com.vinny.backend.common.domain.BaseEntity;
 import com.vinny.backend.User.domain.enums.UserStatus;
 import com.vinny.backend.User.domain.mapping.*;
+import com.vinny.backend.search.domain.SearchLog;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;

--- a/src/main/java/com/vinny/backend/error/ApiResponse.java
+++ b/src/main/java/com/vinny/backend/error/ApiResponse.java
@@ -33,7 +33,7 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> onSuccess(String message, T result) {
-        return new ApiResponse<>(true,SuccessStatus._OK.getCode(), message, result);
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode(), message, result, LocalDateTime.now());
     }
 
 

--- a/src/main/java/com/vinny/backend/error/code/status/ErrorStatus.java
+++ b/src/main/java/com/vinny/backend/error/code/status/ErrorStatus.java
@@ -38,6 +38,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     SHOP_NOT_FOUND(HttpStatus.BAD_REQUEST, "SHOP4001", "존재하지 않는 Shop입니다."),
 
+    // 검색기록 관련 에러
+    SEARCH_LOG_NOT_FOUND_OR_FORBIDDEN(HttpStatus.NOT_FOUND, "SEARCH_LOG_403", "검색 로그를 찾을 수 없거나 삭제 권한이 없습니다."),
+    NO_SEARCH_LOGS_FOUND(HttpStatus.NOT_FOUND, "SEARCH_LOG_404", "검색 기록이 없습니다."),
+    SEARCH_LOG_DELETE_FAILED(HttpStatus.NOT_FOUND, "SEARCH_LOG_400", "검색어 삭제에 실패했습니다.");
 
     ;
 

--- a/src/main/java/com/vinny/backend/search/controller/SearchLogController.java
+++ b/src/main/java/com/vinny/backend/search/controller/SearchLogController.java
@@ -2,8 +2,7 @@ package com.vinny.backend.search.controller;
 
 import com.vinny.backend.error.ApiResponse;
 import com.vinny.backend.search.annotation.CurrentUser;
-import com.vinny.backend.search.dto.SearchLogCreateRequest;
-import com.vinny.backend.search.dto.SearchLogResponse;
+import com.vinny.backend.search.dto.*;
 import com.vinny.backend.search.service.SearchLogService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,10 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/search-logs")
@@ -39,4 +35,54 @@ public class SearchLogController {
         SearchLogResponse response = searchLogService.addSearchLog(userId, request);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
+
+    @Operation(summary = "최근 검색어 목록 조회",
+            description = "사용자의 최근 검색어 목록을 조회합니다. (최대 10개)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<RecentSearchListResponse>> getRecentSearches(
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+
+        RecentSearchListResponse response = searchLogService.getRecentSearches(userId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+
+
+    @Operation(summary = "검색어 개별 삭제",
+            description = "특정 검색어를 삭제합니다. (X 버튼 기능)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "검색 로그를 찾을 수 없음")
+    })
+    @DeleteMapping("/keyword")
+    public ResponseEntity<ApiResponse<SearchLogDeleteResponse>> deleteSearchLog(
+            @Parameter(hidden = true) @CurrentUser Long userId,
+            @RequestBody @Valid SearchLogDeleteRequest request) {
+
+        Long searchLogId = searchLogService.getSearchLogByKeyword(userId, request.keyword());
+        SearchLogDeleteResponse response = searchLogService.deleteSearchLog(userId, searchLogId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+
+    @Operation(summary = "모든 검색어 삭제",
+            description = "사용자의 모든 검색어를 삭제합니다. (모두 삭제 버튼 기능)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @DeleteMapping("/all")
+    public ResponseEntity<ApiResponse<Void>> deleteAllSearchLogs(
+            @Parameter(hidden = true) @CurrentUser Long userId) {
+
+        searchLogService.deleteAllSearchLogs(userId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+
 }

--- a/src/main/java/com/vinny/backend/search/domain/SearchLog.java
+++ b/src/main/java/com/vinny/backend/search/domain/SearchLog.java
@@ -1,5 +1,6 @@
-package com.vinny.backend.User.domain;
+package com.vinny.backend.search.domain;
 
+import com.vinny.backend.User.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/vinny/backend/search/dto/RecentSearchListResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/RecentSearchListResponse.java
@@ -1,0 +1,34 @@
+package com.vinny.backend.search.dto;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "최근 검색어 목록 응답")
+public class RecentSearchListResponse {
+
+    @Schema(description = "최근 검색어 목록")
+    private List<RecentSearchResponse> recentSearches;
+
+    @Schema(description = "총 검색어 개수", example = "5")
+    private int totalCount;
+
+    public static RecentSearchListResponse of(List<RecentSearchResponse> recentSearches) {
+        return RecentSearchListResponse.builder()
+                .recentSearches(recentSearches)
+                .totalCount(recentSearches.size())
+                .build();
+    }
+
+    public static RecentSearchListResponse empty() {
+        return RecentSearchListResponse.builder()
+                .recentSearches(List.of())
+                .totalCount(0)
+                .build();
+    }
+}

--- a/src/main/java/com/vinny/backend/search/dto/RecentSearchResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/RecentSearchResponse.java
@@ -1,0 +1,25 @@
+package com.vinny.backend.search.dto;
+
+import com.vinny.backend.search.domain.SearchLog;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "최근 검색어 응답")
+public class RecentSearchResponse {
+
+    @Schema(description = "검색 로그 ID", example = "1")
+    private Long searchLogId;
+
+    @Schema(description = "검색 키워드", example = "망원빈티지")
+    private String keyword;
+
+    public static RecentSearchResponse from(SearchLog searchLog) {
+        return RecentSearchResponse.builder()
+                .searchLogId(searchLog.getId())
+                .keyword(searchLog.getKeyword())
+                .build();
+    }
+}

--- a/src/main/java/com/vinny/backend/search/dto/SearchLogDeleteRequest.java
+++ b/src/main/java/com/vinny/backend/search/dto/SearchLogDeleteRequest.java
@@ -1,0 +1,13 @@
+package com.vinny.backend.search.dto;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "검색 키워드 삭제 요청 DTO")
+public record SearchLogDeleteRequest(
+
+        @Schema(description = "삭제할 검색 키워드", example = "스트릿 패션")
+        @NotBlank(message = "검색 키워드는 공백일 수 없습니다.")
+        String keyword
+) {}

--- a/src/main/java/com/vinny/backend/search/dto/SearchLogDeleteResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/SearchLogDeleteResponse.java
@@ -1,0 +1,28 @@
+package com.vinny.backend.search.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "검색어 삭제 응답")
+public class SearchLogDeleteResponse {
+
+    @Schema(description = "삭제된 검색어 ID", example = "1")
+    private Long deletedSearchLogId;
+
+    @Schema(description = "삭제 성공 여부", example = "true")
+    private boolean deleted;
+
+    @Schema(description = "메시지", example = "검색어가 삭제되었습니다.")
+    private String message;
+
+    public static SearchLogDeleteResponse success(Long searchLogId) {
+        return SearchLogDeleteResponse.builder()
+                .deletedSearchLogId(searchLogId)
+                .deleted(true)
+                .message("검색어가 삭제되었습니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/vinny/backend/search/dto/SearchLogResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/SearchLogResponse.java
@@ -1,6 +1,6 @@
 package com.vinny.backend.search.dto;
 
-import com.vinny.backend.User.domain.SearchLog;
+import com.vinny.backend.search.domain.SearchLog;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/vinny/backend/search/repository/SearchLogRepository.java
+++ b/src/main/java/com/vinny/backend/search/repository/SearchLogRepository.java
@@ -1,6 +1,6 @@
 package com.vinny.backend.search.repository;
 
-import com.vinny.backend.User.domain.SearchLog;
+import com.vinny.backend.search.domain.SearchLog;
 import com.vinny.backend.User.domain.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -42,4 +42,29 @@ public interface SearchLogRepository extends JpaRepository<SearchLog, Long> {
      */
     @Query("SELECT s FROM SearchLog s WHERE s.user = :user ORDER BY s.searchedAt ASC")
     List<SearchLog> findOldestByUser(@Param("user") User user, Pageable pageable);
+
+
+    /**
+     * 사용자의 최근 검색어 목록 조회 (최신순)
+     */
+    @Query("SELECT s FROM SearchLog s WHERE s.user = :user ORDER BY s.searchedAt DESC")
+    List<SearchLog> findRecentSearchesByUser(@Param("user") User user, Pageable pageable);
+
+
+    /**
+     * 사용자의 모든 검색어 삭제
+     */
+    @Modifying
+    @Query("DELETE FROM SearchLog s WHERE s.user = :user")
+    void deleteAllByUser(@Param("user") User user);
+
+    /**
+     * 사용자의 특정 검색어 삭제 (권한 체크 포함)
+     */
+    @Modifying
+    @Query("DELETE FROM SearchLog s WHERE s.id = :searchLogId AND s.user.id = :userId")
+    int deleteByIdAndUserId(@Param("searchLogId") Long searchLogId, @Param("userId") Long userId);
+
+    Optional<SearchLog> findSearchLogIdByUserAndKeyword(User user, String normalizedKeyword);
 }
+

--- a/src/main/java/com/vinny/backend/search/service/SearchLogService.java
+++ b/src/main/java/com/vinny/backend/search/service/SearchLogService.java
@@ -47,7 +47,7 @@ public class SearchLogService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 키워드 정제 (앞뒤 공백 제거, 소문자 변환 등)
-        String normalizedKeyword = normalizeKeyword(request.getKeyword());
+        String normalizedKeyword = request.getKeyword().trim();
 
         // 중복 검색어 확인
         Optional<SearchLog> existingSearchLog = searchLogRepository


### PR DESCRIPTION
## 📌 연관 이슈
- close #105

## 🌱 PR 요약
사용자가 검색한 키워드를 조회하고 개별/전체 삭제할 수 있는 기능을 구현했습니다.  
검색 UI 상에서 검색어를 누르면 재검색이 가능하고, 각 키워드 옆의 X 버튼 또는 상단의 '모두 삭제' 버튼을 통해 삭제할 수 있도록 백엔드 API를 구현했습니다.

## 🛠 작업 내용
<img width="100%" height="447" alt="Image" src="https://github.com/user-attachments/assets/f5929542-7d01-4aeb-96da-f4de787ce25a" />

<img width="100%" height="345" alt="Image" src="https://github.com/user-attachments/assets/e09e1e05-635d-41fd-bdef-4c3ac6671e3a" />

검색어 목록 조회 및 개별 검색어 삭제 + 검색어 모두 삭제 기능 테스트 가능합니다

## ❗️리뷰어들께
- 검색어 정규화 처리(`normalizeKeyword`) 기준에 대해 한 번 확인 부탁드려요
