### PR TITLE
✨ [Feat/#117] 마이페이지 프로필 정보 조회 기능 api 구현 

### DIFF
--- a/src/main/java/com/vinny/backend/Mypage/Controller/MypageController.java
+++ b/src/main/java/com/vinny/backend/Mypage/Controller/MypageController.java
@@ -1,0 +1,25 @@
+package com.vinny.backend.Mypage.Controller;
+
+import com.vinny.backend.Mypage.Service.MypageService;
+import com.vinny.backend.Mypage.dto.MypageProfileResponse;
+import com.vinny.backend.error.ApiResponse;
+import com.vinny.backend.search.annotation.CurrentUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MypageController {
+
+    private final MypageService mypageService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<MypageProfileResponse>> getMyProfile(@CurrentUser Long userId) {
+        MypageProfileResponse response = mypageService.getMyProfile(userId);
+        return ResponseEntity.ok(ApiResponse.onSuccess("프로필 정보를 조회했습니다.",response));
+    }
+}

--- a/src/main/java/com/vinny/backend/Mypage/Controller/MypageController.java
+++ b/src/main/java/com/vinny/backend/Mypage/Controller/MypageController.java
@@ -4,6 +4,9 @@ import com.vinny.backend.Mypage.Service.MypageService;
 import com.vinny.backend.Mypage.dto.MypageProfileResponse;
 import com.vinny.backend.error.ApiResponse;
 import com.vinny.backend.search.annotation.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,9 +20,17 @@ public class MypageController {
 
     private final MypageService mypageService;
 
+    // ========== 마이페이지 프로필 정보 조회 ==========
+    @Operation(summary = "마이페이지 프로필 정보 조회", description = "닉네임, 프로필 이미지, 코멘트, 게시글 수, 찜한 샵 수, 저장함 수 등을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필 정보 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @GetMapping("/profile")
-    public ResponseEntity<ApiResponse<MypageProfileResponse>> getMyProfile(@CurrentUser Long userId) {
+    public ResponseEntity<ApiResponse<MypageProfileResponse>> getMyProfile(
+            @Parameter(hidden = true) @CurrentUser Long userId) {
         MypageProfileResponse response = mypageService.getMyProfile(userId);
-        return ResponseEntity.ok(ApiResponse.onSuccess("프로필 정보를 조회했습니다.",response));
+        return ResponseEntity.ok(ApiResponse.onSuccess("프로필 정보를 조회했습니다.", response));
     }
 }

--- a/src/main/java/com/vinny/backend/Mypage/Service/MypageService.java
+++ b/src/main/java/com/vinny/backend/Mypage/Service/MypageService.java
@@ -7,6 +7,7 @@ import com.vinny.backend.User.repository.UserShopRepository;
 import com.vinny.backend.error.code.status.ErrorStatus;
 import com.vinny.backend.error.exception.GeneralException;
 import com.vinny.backend.post.repository.PostRepository;
+import com.vinny.backend.post.repository.UserPostLikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,16 +19,16 @@ public class MypageService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final UserShopRepository userShopRepository;
-    private final UserPostLikedRepository userSavedPostRepository;
+    private final UserPostLikeRepository userSavePostRepository;
 
     @Transactional(readOnly = true)
     public MypageProfileResponse getMyProfile(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND);
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         int postCount = postRepository.countByUserId(userId);
         int likedShopCount = userShopRepository.countByUserId(userId);
-        int savedCount = userSavedPostRepository.countByUserId(userId);
+        int savedCount = userSavePostRepository.countByUserId(userId);
 
         return new MypageProfileResponse(
                 user.getId(),

--- a/src/main/java/com/vinny/backend/Mypage/Service/MypageService.java
+++ b/src/main/java/com/vinny/backend/Mypage/Service/MypageService.java
@@ -1,0 +1,42 @@
+package com.vinny.backend.Mypage.Service;
+
+import com.vinny.backend.Mypage.dto.MypageProfileResponse;
+import com.vinny.backend.User.domain.User;
+import com.vinny.backend.User.repository.UserRepository;
+import com.vinny.backend.User.repository.UserShopRepository;
+import com.vinny.backend.error.code.status.ErrorStatus;
+import com.vinny.backend.error.exception.GeneralException;
+import com.vinny.backend.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MypageService {
+
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final UserShopRepository userShopRepository;
+    private final UserPostLikedRepository userSavedPostRepository;
+
+    @Transactional(readOnly = true)
+    public MypageProfileResponse getMyProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND);
+
+        int postCount = postRepository.countByUserId(userId);
+        int likedShopCount = userShopRepository.countByUserId(userId);
+        int savedCount = userSavedPostRepository.countByUserId(userId);
+
+        return new MypageProfileResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImage(),
+                user.getComment(),
+                postCount,
+                likedShopCount,
+                savedCount
+        );
+    }
+}

--- a/src/main/java/com/vinny/backend/Mypage/dto/MypageProfileResponse.java
+++ b/src/main/java/com/vinny/backend/Mypage/dto/MypageProfileResponse.java
@@ -1,0 +1,11 @@
+package com.vinny.backend.Mypage.dto;
+
+public record MypageProfileResponse(
+        Long userId,
+        String nickname,
+        String profileImage,
+        String comment,
+        int postCount,
+        int likedShopCount,
+        int savedCount
+) {}

--- a/src/main/java/com/vinny/backend/User/repository/UserShopRepository.java
+++ b/src/main/java/com/vinny/backend/User/repository/UserShopRepository.java
@@ -14,4 +14,5 @@ public interface UserShopRepository extends JpaRepository<UserShop, Long> {
     Optional<UserShop> findByUserAndShop(User user, Shop shop);
     List<UserShop> findAllByUserAndStatus(User user, UserShopStatus status);
 
+    int countByUserId(Long userId);
 }

--- a/src/main/java/com/vinny/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/vinny/backend/post/repository/PostRepository.java
@@ -53,6 +53,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             @Param("styleName") String styleType,
             @Param("keyword") String keyword,
             Pageable pageable);
+
+    int countByUserId(Long userId);
 }
 
 

--- a/src/main/java/com/vinny/backend/post/repository/UserPostLikeRepository.java
+++ b/src/main/java/com/vinny/backend/post/repository/UserPostLikeRepository.java
@@ -11,4 +11,6 @@ public interface UserPostLikeRepository extends JpaRepository<UserPostLike, Long
     Optional<UserPostLike> findByUserAndPost(User user, Post post);
     boolean existsByUserAndPost(User user, Post post);
     void deleteByUserAndPost(User user, Post post);
+
+    int countByUserId(Long userId);
 }


### PR DESCRIPTION
## 📌 연관 이슈
- close #117

## 🌱 PR 요약
- 마이페이지에서 로그인한 사용자의 프로필 정보를 조회하는 API 구현

## 🛠 작업 내용
- `/api/mypage/profile` GET API 구현
- 사용자 기본 정보 (닉네임, 프로필 이미지, 코멘트) 조회
- 작성한 게시글 수, 찜한 샵 수, 저장함 수 포함
- 인증된 사용자만 접근 가능 (@CurrentUser 활용)
- `MypageController`, `MypageService`, `MypageProfileResponse` 작성
- 예외 처리 및 Swagger 문서화

## ❗️리뷰어들께
![image.png](attachment:eb4737f4-5ae8-4ab1-9dc5-d96380b9f686:image.png)
정보 조회 테스트입니다! 

