### PR TITLE
♻️ [Refactor/#125] JWT AccessToken + RefreshToken 재발급 로직 최적화

### DIFF
--- a/src/main/java/com/vinny/backend/auth/dto/TokenRequestDto.java
+++ b/src/main/java/com/vinny/backend/auth/dto/TokenRequestDto.java
@@ -6,6 +6,5 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TokenRequestDto {
-    private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/com/vinny/backend/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/vinny/backend/auth/jwt/JwtProvider.java
@@ -57,6 +57,7 @@ public class JwtProvider {
                 .compact();
 
         String refreshToken = Jwts.builder()
+                .setSubject(subject)
                 .setExpiration(new Date(now + this.refreshTokenExpirationMilliseconds))
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- #125 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->

### 1. API 요청 간소화
* **Before**: 재발급 시 `accessToken`과 `refreshToken`을 모두 보내야 했습니다.
* **After**: 이제 `refreshToken` 하나만 보내면 되므로 API 호출이 더 간결해졌습니다.

### 2. 사용자 식별 방식 변경
* **Before**: 만료된 `accessToken`에서 사용자 정보를 추출했습니다.
* **After**: 전달받은 `refreshToken`으로 DB를 직접 조회하여 사용자를 식별합니다. 

### 3. 보안 강화 (Refresh Token 초기화)
* **Before**: 기존 `refreshToken`을 계속 사용했습니다.
* **After**: 재발급이 성공할 때마다 새로운 `refreshToken`을 발급하여 DB에 업데이트합니다. 한번 사용된 `refreshToken`은 무효화됩니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
<img width="2048" height="1041" alt="image" src="https://github.com/user-attachments/assets/50174551-72f2-44fa-a8e3-7b701cd0ee75" />

***

<img width="2048" height="568" alt="image" src="https://github.com/user-attachments/assets/a9f2ee99-560b-45b3-95ed-24bdb7439246" />



## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
