### PR TITLE
✨[Feat/#132] 가게 상세조회 Dto 수정, 지도용 가게 썸네일 조회 추가

### DIFF
--- a/src/main/java/com/vinny/backend/Shop/controller/ShopController.java
+++ b/src/main/java/com/vinny/backend/Shop/controller/ShopController.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/shop")
+@RequestMapping("/api")
 @Tag(name = "Shop", description = "빈티지 샵 관련 API")
 @RequiredArgsConstructor
 public class ShopController {
@@ -50,7 +50,7 @@ public class ShopController {
 
 
     @Operation(summary = "샵 검색", description = "키워드로 빈티지샵을 검색합니다.")
-    @GetMapping("/search")
+    @GetMapping("/shop/search")
     public ResponseEntity<?> searchShops(
             @Parameter(description = "검색 키워드", required = true)
             @RequestParam String keyword
@@ -67,7 +67,7 @@ public class ShopController {
         );
     }
 
-    @GetMapping("/search/style")
+    @GetMapping("/shop/search/style")
     @Operation(summary = "스타일별 가게 목록 조회 API",
             description = "특정 스타일에 해당하는 가게 목록을 조회하는 API입니다.")
     @ApiResponses({
@@ -92,11 +92,24 @@ public class ShopController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    @GetMapping("/{shopId}")
+    @GetMapping("/shop/{shopId}")
     public ResponseEntity<ApiResponse<ShopResponseDto.PreviewDto>> getShopDetails(
             @Parameter(description = "가게 ID", required = true) @PathVariable Long shopId
     ) {
         ShopResponseDto.PreviewDto shopDetails = shopService.getShopsDetails(shopId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(shopDetails));
+    }
+
+    @Operation(summary = "지도용 가게 썸네일 조회", description = "특정 가게의 지도용 썸네일 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @GetMapping("/map/shops/{shopId}")
+    public ResponseEntity<ApiResponse<ShopResponseDto.MapThumbnailDto>> getMapThumbnail(
+            @Parameter(description = "가게 ID", required = true) @PathVariable Long shopId
+    ) {
+        ShopResponseDto.MapThumbnailDto shopDetails = shopService.getMapThumbnail(shopId);
         return ResponseEntity.ok(ApiResponse.onSuccess(shopDetails));
     }
 

--- a/src/main/java/com/vinny/backend/Shop/converter/ShopConverter.java
+++ b/src/main/java/com/vinny/backend/Shop/converter/ShopConverter.java
@@ -4,6 +4,7 @@ import com.vinny.backend.Shop.domain.Shop;
 import com.vinny.backend.Shop.domain.enums.Status;
 import com.vinny.backend.Shop.dto.ShopRequestDto;
 import com.vinny.backend.Shop.dto.ShopResponseDto;
+import com.vinny.backend.Shop.dto.ShopVintageStyleDto;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
@@ -46,29 +47,14 @@ public class ShopConverter {
                 .map(img -> new ShopResponseDto.ImageDto(img.getImageUrl(), img.isMainImage()))
                 .collect(Collectors.toList());
 
-        return ShopResponseDto.PreviewDto.builder()
-                .id(shop.getId())
-                .name(shop.getName())
-                .description(shop.getDescription())
-                .status(shop.getStatus().name())
-                .openTime(shop.getOpenTime() != null ? shop.getOpenTime().toString() : null)
-                .closeTime(shop.getCloseTime() != null ? shop.getCloseTime().toString() : null)
-                .instagram(shop.getInstagram())
-                .address(shop.getAddress())
-                .addressDetail(shop.getAddressDetail())
-                .latitude(shop.getLatitude())
-                .longitude(shop.getLongitude())
-                .region(shop.getRegion() != null ? shop.getRegion().getName() : null)
-                .images(images)
-                .build();
-    }
-
-
-    public static ShopResponseDto.PreviewDto toResponseDto(Shop shop) {
-        List<ShopResponseDto.ImageDto> images = shop.getShopImages().stream()
-                .map(img -> new ShopResponseDto.ImageDto(img.getImageUrl(), img.isMainImage()))
+        List<ShopVintageStyleDto> vintageStyleDtos = shop.getShopVintageStyleList().stream()
+                .map(style -> ShopVintageStyleDto.builder()
+                        .id(style.getId())
+                        .vintageStyleName(style.getVintageStyle() != null ? style.getVintageStyle().getName() : null)
+                        .build())
                 .collect(Collectors.toList());
 
+
         return ShopResponseDto.PreviewDto.builder()
                 .id(shop.getId())
                 .name(shop.getName())
@@ -83,6 +69,8 @@ public class ShopConverter {
                 .longitude(shop.getLongitude())
                 .region(shop.getRegion() != null ? shop.getRegion().getName() : null)
                 .images(images)
+                .shopVintageStyleList(vintageStyleDtos)
                 .build();
     }
+
 }

--- a/src/main/java/com/vinny/backend/Shop/converter/ShopConverter.java
+++ b/src/main/java/com/vinny/backend/Shop/converter/ShopConverter.java
@@ -73,4 +73,33 @@ public class ShopConverter {
                 .build();
     }
 
+    public static ShopResponseDto.MapThumbnailDto toMapThumbnailDto(Shop shop) {
+        List<ShopResponseDto.ImageDto> images = shop.getShopImages().stream()
+                .map(img -> new ShopResponseDto.ImageDto(img.getImageUrl(), img.isMainImage()))
+                .collect(Collectors.toList());
+
+        List<ShopVintageStyleDto> vintageStyleDtos = shop.getShopVintageStyleList().stream()
+                .map(style -> ShopVintageStyleDto.builder()
+                        .id(style.getId())
+                        .vintageStyleName(style.getVintageStyle() != null ? style.getVintageStyle().getName() : null)
+                        .build())
+                .collect(Collectors.toList());
+
+
+        return ShopResponseDto.MapThumbnailDto.builder()
+                .id(shop.getId())
+                .name(shop.getName())
+                .openTime(shop.getOpenTime() != null ? shop.getOpenTime().toString() : null)
+                .closeTime(shop.getCloseTime() != null ? shop.getCloseTime().toString() : null)
+                .instagram(shop.getInstagram())
+                .address(shop.getAddress())
+                .addressDetail(shop.getAddressDetail())
+                .latitude(shop.getLatitude())
+                .longitude(shop.getLongitude())
+                .region(shop.getRegion() != null ? shop.getRegion().getName() : null)
+                .images(images)
+                .shopVintageStyleList(vintageStyleDtos)
+                .build();
+    }
+
 }

--- a/src/main/java/com/vinny/backend/Shop/dto/ShopResponseDto.java
+++ b/src/main/java/com/vinny/backend/Shop/dto/ShopResponseDto.java
@@ -47,4 +47,24 @@ public class ShopResponseDto {
         private int totalPages;
         private long totalElements;
     }
+
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MapThumbnailDto {
+        private Long id;
+        private String name;
+        private String openTime;
+        private String closeTime;
+        private String instagram;
+        private String address;
+        private String addressDetail;
+        private Double latitude;
+        private Double longitude;
+        private String region;
+        private List<ImageDto> images;
+        private List<ShopVintageStyleDto> shopVintageStyleList;
+    }
 }

--- a/src/main/java/com/vinny/backend/Shop/dto/ShopResponseDto.java
+++ b/src/main/java/com/vinny/backend/Shop/dto/ShopResponseDto.java
@@ -25,6 +25,7 @@ public class ShopResponseDto {
         private Double longitude;
         private String region;
         private List<ImageDto> images;
+        private List<ShopVintageStyleDto> shopVintageStyleList;
     }
 
 

--- a/src/main/java/com/vinny/backend/Shop/dto/ShopVintageStyleDto.java
+++ b/src/main/java/com/vinny/backend/Shop/dto/ShopVintageStyleDto.java
@@ -1,0 +1,14 @@
+package com.vinny.backend.Shop.dto;
+
+import com.vinny.backend.User.domain.VintageStyle;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ShopVintageStyleDto {
+    private Long id;
+    private String vintageStyleName;
+}

--- a/src/main/java/com/vinny/backend/Shop/service/ShopCommandServiceImpl.java
+++ b/src/main/java/com/vinny/backend/Shop/service/ShopCommandServiceImpl.java
@@ -71,7 +71,7 @@ public class ShopCommandServiceImpl implements ShopCommandService{
 
         shopRepository.save(shop);
 
-        return ShopConverter.toResponseDto(shop);
+        return ShopConverter.toPreviewDto(shop);
     }
 
 

--- a/src/main/java/com/vinny/backend/Shop/service/ShopService.java
+++ b/src/main/java/com/vinny/backend/Shop/service/ShopService.java
@@ -66,4 +66,13 @@ public class ShopService {
         return shopConverter.toPreviewDto(shop);
     }
 
+    /**
+     * 지도용 가게 썸네일  조회
+     */
+    public ShopResponseDto.MapThumbnailDto getMapThumbnail(long shopId) {
+        Shop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
+        return shopConverter.toMapThumbnailDto(shop);
+    }
+
 }

--- a/src/main/java/com/vinny/backend/config/SecurityConfig.java
+++ b/src/main/java/com/vinny/backend/config/SecurityConfig.java
@@ -33,8 +33,9 @@ public class SecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/map/shops/favorite").authenticated()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
-                                "/api/auth/**", "/h2-console/**", "/api/shop/**","/api/post/**", "/files/**").permitAll() // 로그인 및 H2 콘솔 경로는 모두 허용, 배포 시점에 추후 수정 예정
+                                "/api/auth/**", "/h2-console/**", "/api/shop/**","/api/post/**", "/files/**", "/api/map/shops/**").permitAll() // 로그인 및 H2 콘솔 경로는 모두 허용, 배포 시점에 추후 수정 예정
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #132

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
가게 상세조회 Dto 수정, 지도용 가게 썸네일 조회 추가

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
<img width="1775" height="1772" alt="image" src="https://github.com/user-attachments/assets/cf2a2de2-f8c4-4342-8224-51138445d5d5" />
기존에 빠트린 vintageStyleName을 추가하였습니다.

<img width="1775" height="1769" alt="image" src="https://github.com/user-attachments/assets/0af95cf4-097e-4aab-b49e-71e6466da7fc" />
지도용 가게 썸네일 조회 api입니다.
보시면 상세 조회에 있던 설명이 빠진 걸 볼 수 있습니다.
<img width="251" height="548" alt="image" src="https://github.com/user-attachments/assets/6c6987a0-4325-45c2-84f5-e9ccd0915d4c" />

## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
지도 api 경로 때문에 SecurityConfig를 수정했습니다.
/api/map/shops/** 를 허용하고, /api/map/shops/favorite은 인증이 필요하게 했습니다.
