### PR TITLE
🐛 [fix] redis 관련 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   app:
-    image: 912394945783.dkr.ecr.ap-northeast-2.amazonaws.com/vinny-backend:latest
+    image: 912394945783.dkr.ecr.ap-northeast-2.amazonaws.com/vinny-project:latest
     container_name: vinny-app
     restart: always
     ports:
@@ -10,6 +10,9 @@ services:
       - .env
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - REDIS_HOST=redis-stack
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
   redis-stack:
     image: redis/redis-stack:latest
     container_name: redis-stack

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -26,7 +26,7 @@ spring:
     redis:
       host: redis-stack
       port: 6379
-      password: ${REDDIS_STACK_PASSWORD}
+      password: ${REDIS_STACK_PASSWORD}
 
   # OAuth2 설정 구조
   security:


### PR DESCRIPTION
## 📌 연관 이슈
- close #149 

## 🌱 PR 요약
- EC2 환경에서 애플리케이션과 Redis를 동시에 구동할 수 있도록 `docker-compose.yml` 수정

## 🛠 작업 내용
- `app` 서비스에 `SPRING_PROFILES_ACTIVE=prod` 환경변수 추가
- `app` 서비스의 포트 매핑을 `8080:8080`으로 고정
- `redis-stack` 서비스 추가 (데이터 볼륨/설정 파일 마운트 포함)
- `docker compose up -d` 실행 시 자동 재시작(`restart: always`) 설정

## ❗️리뷰어들께

