### PR TITLE
🐛 [fix]  cicd 배포 설정 수정 조건문 추가

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -41,39 +41,60 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_SHA
 
-      - name: 🚀 Deploy to EC2
+      - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
+          username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
+          port: 22
+          timeout: 30s
+          command_timeout: 10m
+          script_stop: true
+          envs: AWS_DEFAULT_REGION,ECR_REGISTRY,ECR_REPOSITORY,IMAGE_TAG
           script: |
-            set -e
+            set -Eeuo pipefail
 
-            ECR_REGISTRY="912394945783.dkr.ecr.ap-northeast-2.amazonaws.com"
-            ECR_REPOSITORY="vinny-project"
-            IMAGE_TAG="latest"
+            ECR_REGISTRY="${ECR_REGISTRY:-912394945783.dkr.ecr.ap-northeast-2.amazonaws.com}"
+            ECR_REPOSITORY="${ECR_REPOSITORY:-vinny-project}"
+            IMAGE_TAG="${IMAGE_TAG:-latest}"
+            REGION="${AWS_DEFAULT_REGION:-ap-northeast-2}"
 
-            # 1) EC2에서 ECR 로그인 (AWS CLI 설치 및 권한 필요)
-            aws ecr get-login-password --region ap-northeast-2 \
-            | docker login --username AWS --password-stdin $ECR_REGISTRY
+            # 1) ECR 로그인
+            aws ecr get-login-password --region "$REGION" \
+              | docker login --username AWS --password-stdin "$ECR_REGISTRY"
 
-            # 2) 8080 포트 점유 프로세스 종료
-            if ss -ltn | awk '{print $4}' | grep -q ":8080$"; then
-              echo "Port 8080 in use. Killing process..."
-              sudo lsof -t -i :8080 | xargs --no-run-if-empty sudo kill -9
+            # 2) 8080을 publish한 모든 컨테이너 종료/삭제 (compose 포함)
+            MAP_IDS=$(docker ps --format '{{.ID}} {{.Ports}}' \
+              | awk '/(0\.0\.0\.0|::):8080->/ {print $1}')
+            if [ -n "${MAP_IDS:-}" ]; then
+              echo "Stopping containers publishing :8080 -> ${MAP_IDS}"
+              docker rm -f $MAP_IDS
             fi
 
-            # 3) 기존 컨테이너 제거
+            # (옵션) compose로 뜬 것이 있으면 orphans까지 내리기
+            # [경로 조정] docker-compose.yml이 있다면 주석 해제
+             if [ -f /home/ubuntu/docker-compose.yml ]; then
+               docker compose -f /home/ubuntu/docker-compose.yml down --remove-orphans
+             fi
+
+            # 3) 이전 앱 컨테이너 정리 (이름 기준)
             docker rm -f vinny-app || true
 
-            # 4) 최신 이미지 풀
-            docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            # 4) 포트 완전 해제 대기 (최대 30초)
+            for i in $(seq 1 30); do
+              if ! ss -lntp | grep -q ':8080'; then break; fi
+              sleep 1
+            done
+            ss -lntp | grep -q ':8080' && { echo "ERROR: 8080 still in use"; docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Ports}}' | (grep 8080 || true); exit 1; }
 
-            # 5) prod 프로필로 컨테이너 실행
-            docker run -d --restart always \
+            # 5) 최신 이미지 pull
+            docker pull "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+            # 6) 컨테이너 실행
+            docker run -d --restart=always \
               --name vinny-app \
-              -p 8080:8080 \
               --env-file /home/ubuntu/.env \
               -e SPRING_PROFILES_ACTIVE=prod \
-              $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+              -p 8080:8080 \
+              "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -74,9 +74,9 @@ jobs:
 
             # (옵션) compose로 뜬 것이 있으면 orphans까지 내리기
             # [경로 조정] docker-compose.yml이 있다면 주석 해제
-             if [ -f /home/ubuntu/docker-compose.yml ]; then
-               docker compose -f /home/ubuntu/docker-compose.yml down --remove-orphans
-             fi
+            if [ -f /home/ubuntu/docker-compose.yml ]; then
+              docker compose -f /home/ubuntu/docker-compose.yml down --remove-orphans
+            fi
 
             # 3) 이전 앱 컨테이너 정리 (이름 기준)
             docker rm -f vinny-app || true

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -86,8 +86,13 @@ jobs:
               if ! ss -lntp | grep -q ':8080'; then break; fi
               sleep 1
             done
-            ss -lntp | grep -q ':8080' && { echo "ERROR: 8080 still in use"; docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Ports}}' | (grep 8080 || true); exit 1; }
-
+            
+            if ss -lntp | grep -q ':8080'; then
+              echo "ERROR: 8080 still in use"
+              docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Ports}}' | (grep 8080 || true)
+              exit 1
+            fi
+            
             # 5) 최신 이미지 pull
             docker pull "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -2,55 +2,78 @@ name: CI/CD to EC2
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   workflow_dispatch:
 
 env:
+  AWS_REGION: ap-northeast-2
   ECR_REGISTRY: 912394945783.dkr.ecr.ap-northeast-2.amazonaws.com
   ECR_REPOSITORY: vinny-project
   IMAGE_TAG: latest
-  AWS_REGION: ap-northeast-2
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - name: ✅ Checkout code
+      - name: ✅ Checkout
         uses: actions/checkout@v4
 
-      - name: 🔐 Configure AWS credentials
+      - name: 🔐 Configure AWS credentials (OIDC 권장)
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: 🐳 Login to Amazon ECR
+      - name: 🐳 Login to Amazon ECR (Runner)
         run: |
           aws ecr get-login-password --region $AWS_REGION \
           | docker login --username AWS --password-stdin $ECR_REGISTRY
 
-      - name: 📦 Build and Push Docker image
+      - name: 📦 Build & Push
         run: |
-          docker build -t $ECR_REPOSITORY:$IMAGE_TAG .
+          GIT_SHA=${{ github.sha }}
+          # latest와 SHA 두 태그 모두 푸시
+          docker build -t $ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REPOSITORY:$GIT_SHA .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REPOSITORY:$GIT_SHA  $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_SHA
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_SHA
 
-      - name: 🚀 Deploy to EC2 via SSH
+      - name: 🚀 Deploy to EC2
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            docker pull 912394945783.dkr.ecr.ap-northeast-2.amazonaws.com/vinny-project:latest
-            docker stop vinny-app || true
-            docker rm vinny-app || true
+            set -e
+
+            ECR_REGISTRY="912394945783.dkr.ecr.ap-northeast-2.amazonaws.com"
+            ECR_REPOSITORY="vinny-project"
+            IMAGE_TAG="latest"
+
+            # 1) EC2에서 ECR 로그인 (AWS CLI 설치 및 권한 필요)
+            aws ecr get-login-password --region ap-northeast-2 \
+            | docker login --username AWS --password-stdin $ECR_REGISTRY
+
+            # 2) 8080 포트 점유 프로세스 종료
+            if ss -ltn | awk '{print $4}' | grep -q ":8080$"; then
+              echo "Port 8080 in use. Killing process..."
+              sudo lsof -t -i :8080 | xargs --no-run-if-empty sudo kill -9
+            fi
+
+            # 3) 기존 컨테이너 제거
+            docker rm -f vinny-app || true
+
+            # 4) 최신 이미지 풀
+            docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+            # 5) prod 프로필로 컨테이너 실행
             docker run -d --restart always \
               --name vinny-app \
-              --env-file /home/ubuntu/.env \
               -p 8080:8080 \
-              912394945783.dkr.ecr.ap-northeast-2.amazonaws.com/vinny-project:latest
-          
+              --env-file /home/ubuntu/.env \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
## 📌 연관 이슈
- close #

## 🌱 PR 요약
배포 스크립트에서 `set -e` 환경에서 `grep -q` 비매치(Exit 1)로 인해 전체 작업이 실패하던 문제를 수정했습니다. 8080 포트 점유 검사 구문을 **안전한 if 블록**으로 변경해 정상 경로에서는 실패로 간주되지 않도록 했습니다. 또한 8080을 점유 중인 컨테이너 정리와 compose 기반 서비스 종료 로직을 유지/정비했습니다.

## 🛠 작업 내용
- `ss -lntp | grep -q ':8080' && { ...; exit 1; }` → **if 조건문**으로 교체
  ```bash
  # 4) 포트 완전 해제 대기 (최대 30초)
  for i in $(seq 1 30); do
    if ! ss -lntp | grep -q ':8080'; then break; fi
    sleep 1
  done

  if ss -lntp | grep -q ':8080'; then
    echo "ERROR: 8080 still in use"
    docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Ports}}' | (grep 8080 || true)
    exit 1
  fi
