### PR TITLE
🐛 [fix] cicd 배포 시 ecr 사용하도록 설정

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -41,39 +41,60 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_SHA
 
-      - name: 🚀 Deploy to EC2
+      - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
+          username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
+          port: 22
+          timeout: 30s
+          command_timeout: 10m
+          script_stop: true
+          envs: AWS_DEFAULT_REGION,ECR_REGISTRY,ECR_REPOSITORY,IMAGE_TAG
           script: |
-            set -e
+            set -Eeuo pipefail
 
-            ECR_REGISTRY="912394945783.dkr.ecr.ap-northeast-2.amazonaws.com"
-            ECR_REPOSITORY="vinny-project"
-            IMAGE_TAG="latest"
+            ECR_REGISTRY="${ECR_REGISTRY:-912394945783.dkr.ecr.ap-northeast-2.amazonaws.com}"
+            ECR_REPOSITORY="${ECR_REPOSITORY:-vinny-project}"
+            IMAGE_TAG="${IMAGE_TAG:-latest}"
+            REGION="${AWS_DEFAULT_REGION:-ap-northeast-2}"
 
-            # 1) EC2에서 ECR 로그인 (AWS CLI 설치 및 권한 필요)
-            aws ecr get-login-password --region ap-northeast-2 \
-            | docker login --username AWS --password-stdin $ECR_REGISTRY
+            # 1) ECR 로그인
+            aws ecr get-login-password --region "$REGION" \
+              | docker login --username AWS --password-stdin "$ECR_REGISTRY"
 
-            # 2) 8080 포트 점유 프로세스 종료
-            if ss -ltn | awk '{print $4}' | grep -q ":8080$"; then
-              echo "Port 8080 in use. Killing process..."
-              sudo lsof -t -i :8080 | xargs --no-run-if-empty sudo kill -9
+            # 2) 8080을 publish한 모든 컨테이너 종료/삭제 (compose 포함)
+            MAP_IDS=$(docker ps --format '{{.ID}} {{.Ports}}' \
+              | awk '/(0\.0\.0\.0|::):8080->/ {print $1}')
+            if [ -n "${MAP_IDS:-}" ]; then
+              echo "Stopping containers publishing :8080 -> ${MAP_IDS}"
+              docker rm -f $MAP_IDS
             fi
 
-            # 3) 기존 컨테이너 제거
+            # (옵션) compose로 뜬 것이 있으면 orphans까지 내리기
+            # [경로 조정] docker-compose.yml이 있다면 주석 해제
+             if [ -f /home/ubuntu/docker-compose.yml ]; then
+               docker compose -f /home/ubuntu/docker-compose.yml down --remove-orphans
+             fi
+
+            # 3) 이전 앱 컨테이너 정리 (이름 기준)
             docker rm -f vinny-app || true
 
-            # 4) 최신 이미지 풀
-            docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            # 4) 포트 완전 해제 대기 (최대 30초)
+            for i in $(seq 1 30); do
+              if ! ss -lntp | grep -q ':8080'; then break; fi
+              sleep 1
+            done
+            ss -lntp | grep -q ':8080' && { echo "ERROR: 8080 still in use"; docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Ports}}' | (grep 8080 || true); exit 1; }
 
-            # 5) prod 프로필로 컨테이너 실행
-            docker run -d --restart always \
+            # 5) 최신 이미지 pull
+            docker pull "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+            # 6) 컨테이너 실행
+            docker run -d --restart=always \
               --name vinny-app \
-              -p 8080:8080 \
               --env-file /home/ubuntu/.env \
               -e SPRING_PROFILES_ACTIVE=prod \
-              $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+              -p 8080:8080 \
+              "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -74,9 +74,9 @@ jobs:
 
             # (옵션) compose로 뜬 것이 있으면 orphans까지 내리기
             # [경로 조정] docker-compose.yml이 있다면 주석 해제
-             if [ -f /home/ubuntu/docker-compose.yml ]; then
-               docker compose -f /home/ubuntu/docker-compose.yml down --remove-orphans
-             fi
+            if [ -f /home/ubuntu/docker-compose.yml ]; then
+              docker compose -f /home/ubuntu/docker-compose.yml down --remove-orphans
+            fi
 
             # 3) 이전 앱 컨테이너 정리 (이름 기준)
             docker rm -f vinny-app || true

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -34,14 +34,13 @@ jobs:
       - name: 📦 Build & Push
         run: |
           GIT_SHA=${{ github.sha }}
-          # latest와 SHA 두 태그 모두 푸시
           docker build -t $ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REPOSITORY:$GIT_SHA .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker tag $ECR_REPOSITORY:$GIT_SHA  $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_SHA
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_SHA
 
-      - name: Deploy to EC2
+      - name: 🚀 Deploy to EC2 (Compose only)
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.EC2_HOST }}
@@ -55,52 +54,23 @@ jobs:
           script: |
             set -Eeuo pipefail
 
-            ECR_REGISTRY="${ECR_REGISTRY:-912394945783.dkr.ecr.ap-northeast-2.amazonaws.com}"
-            ECR_REPOSITORY="${ECR_REPOSITORY:-vinny-project}"
-            IMAGE_TAG="${IMAGE_TAG:-latest}"
             REGION="${AWS_DEFAULT_REGION:-ap-northeast-2}"
+            COMPOSE_DIR="/home/ubuntu"
+            COMPOSE_FILE="$COMPOSE_DIR/docker-compose.yml"
 
-            # 1) ECR 로그인
+            # 1) ECR 로그인 (EC2)
             aws ecr get-login-password --region "$REGION" \
               | docker login --username AWS --password-stdin "$ECR_REGISTRY"
 
-            # 2) 8080을 publish한 모든 컨테이너 종료/삭제 (compose 포함)
-            MAP_IDS=$(docker ps --format '{{.ID}} {{.Ports}}' \
-              | awk '/(0\.0\.0\.0|::):8080->/ {print $1}')
-            if [ -n "${MAP_IDS:-}" ]; then
-              echo "Stopping containers publishing :8080 -> ${MAP_IDS}"
-              docker rm -f $MAP_IDS
-            fi
+            # 2) compose에서 사용할 변수 export (compose 파일이 변수화돼 있다면)
+            export ECR_REGISTRY ECR_REPOSITORY IMAGE_TAG
 
-            # (옵션) compose로 뜬 것이 있으면 orphans까지 내리기
-            # [경로 조정] docker-compose.yml이 있다면 주석 해제
-            if [ -f /home/ubuntu/docker-compose.yml ]; then
-              docker compose -f /home/ubuntu/docker-compose.yml down --remove-orphans
-            fi
+            # 3) compose 디렉터리로 이동 (.env 상대경로 보장)
+            cd "$COMPOSE_DIR"
 
-            # 3) 이전 앱 컨테이너 정리 (이름 기준)
-            docker rm -f vinny-app || true
+            # 4) 최신 이미지 pull 후 변경분만 재생성 (네트워크/볼륨 유지)
+            docker compose -f "$COMPOSE_FILE" pull
+            docker compose -f "$COMPOSE_FILE" up -d --remove-orphans --no-build --pull always
 
-            # 4) 포트 완전 해제 대기 (최대 30초)
-            for i in $(seq 1 30); do
-              if ! ss -lntp | grep -q ':8080'; then break; fi
-              sleep 1
-            done
-           
-            if ss -lntp | grep -q ':8080'; then
-              echo "ERROR: 8080 still in use"
-              docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Ports}}' | (grep 8080 || true)
-              exit 1
-            fi
-            
-
-            # 5) 최신 이미지 pull
-            docker pull "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
-            # 6) 컨테이너 실행
-            docker run -d --restart=always \
-              --name vinny-app \
-              --env-file /home/ubuntu/.env \
-              -e SPRING_PROFILES_ACTIVE=prod \
-              -p 8080:8080 \
-              "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+            # (옵션) 오래된 dangling 이미지 정리
+            docker image prune -f

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -86,8 +86,13 @@ jobs:
               if ! ss -lntp | grep -q ':8080'; then break; fi
               sleep 1
             done
-            ss -lntp | grep -q ':8080' && { echo "ERROR: 8080 still in use"; docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Ports}}' | (grep 8080 || true); exit 1; }
-
+            
+            if ss -lntp | grep -q ':8080'; then
+              echo "ERROR: 8080 still in use"
+              docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Ports}}' | (grep 8080 || true)
+              exit 1
+            fi
+            
             # 5) 최신 이미지 pull
             docker pull "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -2,55 +2,78 @@ name: CI/CD to EC2
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   workflow_dispatch:
 
 env:
+  AWS_REGION: ap-northeast-2
   ECR_REGISTRY: 912394945783.dkr.ecr.ap-northeast-2.amazonaws.com
   ECR_REPOSITORY: vinny-project
   IMAGE_TAG: latest
-  AWS_REGION: ap-northeast-2
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - name: ✅ Checkout code
+      - name: ✅ Checkout
         uses: actions/checkout@v4
 
-      - name: 🔐 Configure AWS credentials
+      - name: 🔐 Configure AWS credentials (OIDC 권장)
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: 🐳 Login to Amazon ECR
+      - name: 🐳 Login to Amazon ECR (Runner)
         run: |
           aws ecr get-login-password --region $AWS_REGION \
           | docker login --username AWS --password-stdin $ECR_REGISTRY
 
-      - name: 📦 Build and Push Docker image
+      - name: 📦 Build & Push
         run: |
-          docker build -t $ECR_REPOSITORY:$IMAGE_TAG .
+          GIT_SHA=${{ github.sha }}
+          # latest와 SHA 두 태그 모두 푸시
+          docker build -t $ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REPOSITORY:$GIT_SHA .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REPOSITORY:$GIT_SHA  $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_SHA
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GIT_SHA
 
-      - name: 🚀 Deploy to EC2 via SSH
+      - name: 🚀 Deploy to EC2
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
-            docker pull 912394945783.dkr.ecr.ap-northeast-2.amazonaws.com/vinny-project:latest
-            docker stop vinny-app || true
-            docker rm vinny-app || true
+            set -e
+
+            ECR_REGISTRY="912394945783.dkr.ecr.ap-northeast-2.amazonaws.com"
+            ECR_REPOSITORY="vinny-project"
+            IMAGE_TAG="latest"
+
+            # 1) EC2에서 ECR 로그인 (AWS CLI 설치 및 권한 필요)
+            aws ecr get-login-password --region ap-northeast-2 \
+            | docker login --username AWS --password-stdin $ECR_REGISTRY
+
+            # 2) 8080 포트 점유 프로세스 종료
+            if ss -ltn | awk '{print $4}' | grep -q ":8080$"; then
+              echo "Port 8080 in use. Killing process..."
+              sudo lsof -t -i :8080 | xargs --no-run-if-empty sudo kill -9
+            fi
+
+            # 3) 기존 컨테이너 제거
+            docker rm -f vinny-app || true
+
+            # 4) 최신 이미지 풀
+            docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+            # 5) prod 프로필로 컨테이너 실행
             docker run -d --restart always \
               --name vinny-app \
-              --env-file /home/ubuntu/.env \
               -p 8080:8080 \
-              912394945783.dkr.ecr.ap-northeast-2.amazonaws.com/vinny-project:latest
-          
+              --env-file /home/ubuntu/.env \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
## 📌 연관 이슈
- close #

## 🌱 PR 요약
GitHub Actions의 **EC2 배포 방식을 Docker Compose 전용으로 표준화**했습니다. `docker run`/포트 강제 종료 로직을 제거하고, **`docker compose pull && up -d`**로 네트워크/DNS(예: `redis-stack`)를 유지한 채 변경된 서비스만 안전하게 교체합니다.

## 🛠 작업 내용
- Deploy 스텝을 **Compose 전용**으로 교체
  - EC2에서 ECR 로그인 후 `docker compose pull`
  - `docker compose up -d --remove-orphans --no-build --pull always`
- Compose 변수 주입을 위해 **`ECR_REGISTRY`, `ECR_REPOSITORY`, `IMAGE_TAG` export**
- `.env`와 `docker-compose.yml`이 있는 **서버 디렉터리로 이동** 후 명령 실행
- (옵션) 배포 후 **dangling 이미지 정리(`docker image prune -f`)**
- `compose down`/`8080` 포트 점유 강제 종료/`docker run` 사용 제거 → **DNS/네트워크 보존 및 충돌 최소화**

## ❗️리뷰어들께
