### PR TITLE
🐛 [fix]: redis 서버 안 켜도 서버 켜지도록 설정

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -84,3 +84,7 @@ cloud:
       static: "ap-northeast-2"
     stack:
       auto: false
+
+feature:
+  autocomplete:
+    init: true


### PR DESCRIPTION
## 📌 연관 이슈
- close #160 

## 🌱 PR 요약
- `BrandSearchService` 초기화 로직 실행 시점을 `@PostConstruct` → `@EventListener(ApplicationReadyEvent.class)`로 변경
- `feature.autocomplete.init` 프로퍼티 값에 따라 초기 인덱싱 실행 여부를 제어하도록 수정
- Redis 연결 실패 시 애플리케이션이 죽지 않고 경고 로그만 남기도록 예외 처리 추가

## 🛠 작업 내용
- `BrandSearchService`  
  - 초기화 메서드 어노테이션 변경 (`@PostConstruct` → `@EventListener(ApplicationReadyEvent.class)`)
  - `@ConditionalOnProperty` 적용 위치 조정 → 서비스는 항상 빈으로 생성, 초기화 로직만 조건부 실행
  - 초기 인덱싱 시 Redis 예외 처리(`try-catch`) 추가
- `application-*.yml`
  - `feature.autocomplete.init` 설정값 추가 (prod: true, local: false)

## ❗️리뷰어들께
- 로컬 환경에서 `feature.autocomplete.init`을 false로 두면 Redis 없이도 앱이 실행됩니다.
- 배포 환경에서만 초기 인덱싱을 돌리려면 `application-prod.yml`에서 해당 값을 true로 유지해야 합니다.
