### PR TITLE
♻️ [refactor] 검색 기능 검색바와 카테고리 검색으로 구별

### DIFF
--- a/src/main/java/com/vinny/backend/Shop/controller/ShopController.java
+++ b/src/main/java/com/vinny/backend/Shop/controller/ShopController.java
@@ -49,24 +49,6 @@ public class ShopController {
 //    }
 
 
-    @Operation(summary = "샵 검색", description = "키워드로 빈티지샵을 검색합니다.")
-    @GetMapping("/shop/search")
-    public ResponseEntity<?> searchShops(
-            @Parameter(description = "검색 키워드", required = true)
-            @RequestParam String keyword
-    ) {
-        List<ShopSearchResponseDto.ShopDto> shops = shopService.searchShops(keyword);
-        return ResponseEntity.ok(
-                Map.of(
-                        "success", true,
-                        "message", "샵 검색 결과입니다.",
-                        "status", 200,
-                        "data", Map.of("shops", shops),
-                        "timestamp", LocalDateTime.now()
-                )
-        );
-    }
-
     @GetMapping("/shop/search/style")
     @Operation(summary = "스타일별 가게 목록 조회",
             description = "피그마 검색/메인에 있는 카테고리로 모아보기입니다. 스타일별 가게 목록을 조회합니다.")

--- a/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
+++ b/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
@@ -1,6 +1,7 @@
 package com.vinny.backend.Shop.repository;
 
 import com.vinny.backend.Shop.domain.Shop;
+import com.vinny.backend.Shop.domain.enums.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,6 +19,8 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
         LEFT JOIN s.region r
         WHERE LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
            OR LOWER(vs.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+           OR LOWER(s.address) LIKE LOWER(CONCAT('%', :keyword, '%'))
+           OR LOWER(s.description) LIKE LOWER(CONCAT('%', :keyword, '%'))
            OR LOWER(r.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
     """)
     List<Shop> searchByNameOrStyleOrRegion(@Param("keyword") String keyword);
@@ -30,7 +33,6 @@ public interface ShopRepository extends JpaRepository<Shop, Long> {
         JOIN s.shopVintageStyleList svs 
         JOIN svs.vintageStyle vs 
         WHERE vs.name = :styleName 
-        AND s.status = 'OPEN'
         """)
     Page<Shop> findByStyle(@Param("styleName") String styleType, Pageable pageable);
 

--- a/src/main/java/com/vinny/backend/Shop/service/ShopService.java
+++ b/src/main/java/com/vinny/backend/Shop/service/ShopService.java
@@ -26,24 +26,6 @@ public class ShopService {
     private final ShopRepository shopRepository;
     private final ShopConverter shopConverter;
 
-
-    public List<ShopSearchResponseDto.ShopDto> searchShops(String keyword) {
-        List<Shop> shops = shopRepository.searchByNameOrStyleOrRegion(keyword);
-
-        return shops.stream()
-                .map(shop -> new ShopSearchResponseDto.ShopDto(
-                        shop.getId(),
-                        shop.getName(),
-                        shop.getRegion() != null ? shop.getRegion().getName() : null,
-                        shop.getShopVintageStyleList().stream()
-                                .map(svs -> svs.getVintageStyle().getName())
-                                .toList(),
-                        shop.getShopImages().isEmpty() ? null : shop.getShopImages().get(0).getImageUrl()
-                ))
-                .toList();
-    }
-
-
     private static final int PAGE_SIZE = 5;  // 한 페이지당 5개씩 (임시)
 
 

--- a/src/main/java/com/vinny/backend/post/controller/PostController.java
+++ b/src/main/java/com/vinny/backend/post/controller/PostController.java
@@ -41,24 +41,6 @@ public class PostController {
     private final PostLikeService postLikeService;
 
 
-    @Operation(summary = "게시글 검색", description = "키워드로 게시글을 검색합니다.")
-    @GetMapping("/search")
-    public ResponseEntity<?> searchPosts(
-            @Parameter(description = "검색 키워드", required = true)
-            @RequestParam String keyword
-    ) {
-        List<PostSearchResponseDto.PostDto> posts = postService.searchPosts(keyword);
-        return ResponseEntity.ok(
-                Map.of(
-                        "success", true,
-                        "message", "게시글 검색 결과입니다.",
-                        "status", 200,
-                        "data", Map.of("posts", posts),
-                        "timestamp", LocalDateTime.now()
-                )
-        );
-    }
-
     @Operation(summary = "전체 피드 조회", description = "페이징 기반으로 전체 게시글 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<PostResponseDto>> getAllPosts(

--- a/src/main/java/com/vinny/backend/post/repository/PostRepository.java
+++ b/src/main/java/com/vinny/backend/post/repository/PostRepository.java
@@ -27,6 +27,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
         LEFT JOIN st.vintageStyle vs
         WHERE LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
            OR LOWER(u.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
+           OR LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
            OR LOWER(b.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
            OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
            OR LOWER(vs.name) LIKE LOWER(CONCAT('%', :keyword, '%'))

--- a/src/main/java/com/vinny/backend/post/service/PostService.java
+++ b/src/main/java/com/vinny/backend/post/service/PostService.java
@@ -40,21 +40,6 @@ public class PostService {
     private final VintageStyleRepository styleRepository;
     private final S3Service s3Service;
 
-    public List<PostSearchResponseDto.PostDto> searchPosts(String keyword) {
-        List<Post> posts = postRepository.searchByKeyword(keyword);
-
-        return posts.stream().map(post -> new PostSearchResponseDto.PostDto(
-                post.getId(),
-                post.getTitle(),
-                post.getImages().isEmpty() ? null : post.getImages().get(0).getImageUrl(),
-                post.getLikes() != null ? post.getLikes().size() : 0,
-                false, // isLiked (Boolean) - 실 사용시 수정 칠요
-                List.of(), //수정 필요
-                post.getUser().getNickname()
-        )).toList();
-
-    }
-
     public PostResponseDto getAllposts(Pageable pageable, Long currentUserId) {
 //        //정렬 조건 추가
 //        Pageable sortedPageable = PageRequest.of(

--- a/src/main/java/com/vinny/backend/search/controller/SearchController.java
+++ b/src/main/java/com/vinny/backend/search/controller/SearchController.java
@@ -2,6 +2,7 @@ package com.vinny.backend.search.controller;
 
 import com.vinny.backend.error.ApiResponse;
 import com.vinny.backend.search.dto.PostResponse;
+import com.vinny.backend.search.dto.PostSearchResponse;
 import com.vinny.backend.search.dto.ShopResponse;
 import com.vinny.backend.search.dto.StyleSearchRequest;
 import com.vinny.backend.search.service.PostSearchService;
@@ -18,6 +19,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/search")
 @RequiredArgsConstructor
@@ -28,7 +31,7 @@ public class SearchController {
     private final ShopSearchService shopSearchService;
 
     // ========== POST 검색 ==========
-    @Operation(summary = "스타일별 게시물 검색", description = "스타일 타입/키워드/지역 등으로 게시물을 검색합니다.")
+    @Operation(summary = "스타일별 카테고리를 이용한 게시물 검색", description = "스타일 타입/키워드/지역 등으로 게시물을 검색합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
@@ -45,7 +48,7 @@ public class SearchController {
 
 
     // ========== SHOP 검색 ==========
-    @Operation(summary = "스타일별 매장 검색", description = "스타일 타입/키워드/지역 등으로 매장을 검색합니다.")
+    @Operation(summary = "스타일별 카테고리를 이용한 매장 검색", description = "스타일 타입/키워드/지역 등으로 매장을 검색합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
@@ -59,4 +62,41 @@ public class SearchController {
         return ResponseEntity.ok(ApiResponse.onSuccess(
                 request.styleType() + " 스타일 매장 검색 완료", results));
     }
+
+    @Operation(
+            summary = "검색바를 이용한 게시글 검색",
+            description = "키워드(부분 일치)로 게시글을 검색합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @GetMapping("/posts/search")
+    public ResponseEntity<ApiResponse<List<PostSearchResponse.PostImagesDto>>> searchPostsByKeyword(
+            @Parameter(description = "검색 키워드", required = true, example = "데님")
+            @RequestParam String keyword
+    ) {
+        List<PostSearchResponse.PostImagesDto> posts = postSearchService.searchPosts(keyword);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess("검색바를 이용한 게시글 검색 완료", posts)
+        );
+    }
+
+    @Operation(summary = "검색바를 이용한 샵 검색", description = "키워드(부분 일치)로 빈티지샵을 검색합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @GetMapping("/shop/search")
+    public ResponseEntity<ApiResponse<List<ShopResponse>>> searchShops(
+            @Parameter(description = "검색 키워드", required = true, example = "홍대")
+            @RequestParam String keyword
+    ) {
+        List<ShopResponse> shops = shopSearchService.searchShops(keyword);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess("검색바를 이용한 샵 검색 완료", shops)
+        );
+    }
+
+
 }

--- a/src/main/java/com/vinny/backend/search/dto/PostSearchResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/PostSearchResponse.java
@@ -1,0 +1,12 @@
+package com.vinny.backend.search.dto;
+
+import java.util.List;
+
+// package 및 클래스는 기존 위치 유지
+public class PostSearchResponse {
+
+    public static record PostImagesDto(
+            Long id,
+            List<String> imageUrls
+    ) {}
+}

--- a/src/main/java/com/vinny/backend/search/dto/StyleSearchRequest.java
+++ b/src/main/java/com/vinny/backend/search/dto/StyleSearchRequest.java
@@ -7,11 +7,6 @@ import jakarta.validation.constraints.NotNull;
 public record StyleSearchRequest(
         @Schema(description = "스타일 타입", example = "VINTAGE")
         @NotNull(message = "스타일은 필수입니다.")
-        String styleType,
+        String styleType
 
-        @Schema(description = "검색 키워드", example = "자켓")
-        String keyword,
-
-        @Schema(description = "지역명", example = "서울")
-        String region
 ) {}

--- a/src/main/java/com/vinny/backend/search/service/PostSearchService.java
+++ b/src/main/java/com/vinny/backend/search/service/PostSearchService.java
@@ -1,8 +1,10 @@
 package com.vinny.backend.search.service;
 
 import com.vinny.backend.post.domain.Post;
+import com.vinny.backend.post.domain.PostImage;
 import com.vinny.backend.post.repository.PostRepository;
 import com.vinny.backend.search.dto.PostResponse;
+import com.vinny.backend.search.dto.PostSearchResponse;
 import com.vinny.backend.search.dto.StyleSearchRequest;
 import com.vinny.backend.search.dto.UserSearchResponse;
 import lombok.RequiredArgsConstructor;
@@ -26,12 +28,7 @@ public class PostSearchService {
     public Page<PostResponse> searchByStyle(StyleSearchRequest request, Pageable pageable) {
         Page<Post> posts;
 
-        if (request.keyword() != null && !request.keyword().trim().isEmpty()) {
-            posts = postRepository.findByStyleAndKeyword(
-                    request.styleType(), request.keyword(), pageable);
-        } else {
             posts = postRepository.findByStyle(request.styleType(), pageable);
-        }
 
         return posts.map(this::convertToResponse);
     }
@@ -64,5 +61,19 @@ public class PostSearchService {
                 .totalImageCount(imageUrls.size())
                 .likeCount(post.getLikes().size())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostSearchResponse.PostImagesDto> searchPosts(String keyword) {
+        List<Post> posts = postRepository.searchByKeyword(keyword);
+
+        return posts.stream()
+                .map(post -> new PostSearchResponse.PostImagesDto(
+                        post.getId(),
+                        post.getImages().stream()
+                                .map(PostImage::getImageUrl)
+                                .toList()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/vinny/backend/search/service/ShopSearchService.java
+++ b/src/main/java/com/vinny/backend/search/service/ShopSearchService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,12 +24,7 @@ public class ShopSearchService {
     public Page<ShopResponse> searchByStyle(StyleSearchRequest request, Pageable pageable) {
         Page<Shop> shops;
 
-        if (request.region() != null && !request.region().trim().isEmpty()) {
-            shops = shopRepository.findByStyleAndRegion(
-                    request.styleType(), request.region(), pageable);
-        } else {
             shops = shopRepository.findByStyle(request.styleType(), pageable);
-        }
 
         return shops.map(this::convertToResponse);
     }
@@ -47,4 +43,29 @@ public class ShopSearchService {
                 .status(shop.getStatus().name())
                 .build();
     }
+
+
+    @Transactional(readOnly = true)
+    public List<ShopResponse> searchShops(String keyword) {
+        List<Shop> shops = shopRepository.searchByNameOrStyleOrRegion(keyword);
+
+        return shops.stream()
+                .map(shop -> ShopResponse.builder()
+                        .id(shop.getId())
+                        .name(shop.getName())
+                        .address(shop.getAddress())                // 엔티티 필드명에 맞게 조정
+                        .addressDetail(shop.getAddressDetail())    // 엔티티 필드명에 맞게 조정
+                        .region(shop.getRegion() != null ? shop.getRegion().getName() : null)
+                        .styles(shop.getShopVintageStyleList().stream()
+                                .map(svs -> svs.getVintageStyle().getName())
+                                .toList())
+                        .imageUrl(shop.getShopImages().isEmpty()
+                                ? null
+                                : shop.getShopImages().get(0).getImageUrl()) // 대표 이미지 정책에 맞게 수정 가능
+                        .status(shop.getStatus() != null ? shop.getStatus().toString() : null) // Enum이면 .name()
+                        .build()
+                )
+                .toList();
+    }
+
 }


### PR DESCRIPTION
## 📌 연관 이슈
- close #164 

## 🌱 PR 요약
검색바 기반의 **게시글/샵 검색 API**를 추가하고, 응답 스펙을 정리했습니다.  
게시글은 `id + imageUrls[]` 최소 정보만, 샵은 `ShopResponse` DTO로 핵심 필드만 반환합니다.  
Swagger 문서화도 포함했습니다.

## 🛠 작업 내용
- Controller
  - `GET /posts/search` → 키워드로 게시글 검색  
    - Swagger: `@Operation(summary = "검색바를 이용한 게시글 검색", ...)`
    - 응답: `ApiResponse<List<PostSearchResponseDto.PostImagesDto>>`
  - `GET /shop/search` → 키워드로 샵 검색  
    - Swagger: `@Operation(summary = "검색바를 이용한 샵 검색", ...)`
    - 응답: `ApiResponse<List<ShopResponse>>`
- Service
  - `postService.searchPosts(keyword)`  
    - 반환: `PostImagesDto(id, imageUrls[])`
  - `shopService.searchShops(keyword)`  
    - 반환: `ShopResponse(id, name, address, addressDetail, region, styles[], imageUrl, status)`
- DTO
  - `PostSearchResponseDto.PostImagesDto` 추가 (record)
  - `ShopResponse` 사용 (record, @Builder)
- Repository 최적화 (N+1 방지 및 중복 제거)
  - `PostRepository.searchByKeyword(...)`  
  - `ShopRepository.searchByNameOrStyleOrRegion(...)`  
  - 응답 포맷 통일: `ApiResponse.onSuccess("검색바를 이용한 ... 검색 완료", data)`

## ❗️리뷰어들께
