### PR TITLE
✨ [feat] 마이페이지 프로필 사진 및 닉네임, 코멘트 수정 기능 구현

### DIFF
--- a/src/main/java/com/vinny/backend/Mypage/Service/MypageService.java
+++ b/src/main/java/com/vinny/backend/Mypage/Service/MypageService.java
@@ -1,13 +1,12 @@
 package com.vinny.backend.Mypage.Service;
-import com.vinny.backend.Mypage.dto.MypageLikedShopResponse;
-import com.vinny.backend.Mypage.dto.MypagePostThumbnailResponse;
-import com.vinny.backend.Mypage.dto.MypageProfileResponse;
+import com.vinny.backend.Mypage.dto.*;
 import com.vinny.backend.Shop.domain.Shop;
 import com.vinny.backend.Shop.domain.ShopImage;
 import com.vinny.backend.User.domain.User;
 import com.vinny.backend.User.domain.mapping.UserShop;
 import com.vinny.backend.Mypage.dto.MypageProfileResponse;
 import com.vinny.backend.User.domain.User;
+import com.vinny.backend.User.dto.UserProfileDto;
 import com.vinny.backend.User.repository.UserRepository;
 import com.vinny.backend.User.repository.UserShopRepository;
 import com.vinny.backend.error.code.status.ErrorStatus;
@@ -98,4 +97,39 @@ public class MypageService {
                 .toList();
     }
 
+    /*
+    Mypage 유저 정보 수정 api
+     */
+    @Transactional
+    public MypageUserProfileDto updateProfile(Long userId, MypageUpdateProfileRequest req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        if (req.nickname() != null && !req.nickname().isBlank()) {
+            user.updateNickname(req.nickname());
+        }
+        if (req.comment() != null) {
+            user.updateComment(req.comment());
+        }
+
+        return toProfileDto(user);
+    }
+
+    private MypageUserProfileDto toProfileDto(User u) {
+        return new MypageUserProfileDto(
+                u.getId(),
+                u.getNickname(),
+                u.getProfileImage(),
+                u.getComment()
+        );
+    }
+
+    @Transactional
+    public MypageUserProfileDto updateProfileImage(Long userId,  MypageUpdateProfileImageRequest req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        user.updateProfileImage(req.imageUrl());
+        return toProfileDto(user);
+    }
 }

--- a/src/main/java/com/vinny/backend/Mypage/dto/MypageUpdateProfileImageRequest.java
+++ b/src/main/java/com/vinny/backend/Mypage/dto/MypageUpdateProfileImageRequest.java
@@ -1,0 +1,8 @@
+package com.vinny.backend.Mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MypageUpdateProfileImageRequest (
+        @NotBlank(message = "이미지 URL은 필수입니다.")
+        String imageUrl
+) {}

--- a/src/main/java/com/vinny/backend/Mypage/dto/MypageUpdateProfileRequest.java
+++ b/src/main/java/com/vinny/backend/Mypage/dto/MypageUpdateProfileRequest.java
@@ -1,0 +1,13 @@
+package com.vinny.backend.Mypage.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record MypageUpdateProfileRequest(
+        @Size(min = 1, max = 10, message = "닉네임은 1~10자입니다.")
+        String nickname,
+
+        @Size(max = 100, message = "코멘트는 최대 100자입니다.")
+        String comment
+) {}
+
+

--- a/src/main/java/com/vinny/backend/Mypage/dto/MypageUserProfileDto.java
+++ b/src/main/java/com/vinny/backend/Mypage/dto/MypageUserProfileDto.java
@@ -1,0 +1,9 @@
+package com.vinny.backend.Mypage.dto;
+
+public record MypageUserProfileDto (
+        Long userId,
+        String nickname,
+        String profileImage,
+        String comment
+)
+{}

--- a/src/main/java/com/vinny/backend/User/domain/User.java
+++ b/src/main/java/com/vinny/backend/User/domain/User.java
@@ -100,4 +100,6 @@ public class User extends BaseEntity {
     public void changeStatus(UserStatus userStatus) {
         this.userStatus = userStatus;
     }
+
+    public void updateProfileImage(String imageUrl){ this.profileImage = imageUrl; }
 }


### PR DESCRIPTION
## 📌 연관 이슈
- close #123

## 🌱 PR 요약
마이페이지에서
- 닉네임/코멘트 부분 수정(PATCH `/api/mypage`)
- 프로필 이미지 업로드+반영을 한 번에 수행(PATCH `/api/mypage/profile-image`, `multipart/form-data`)
하도록 구현했습니다.  
응답은 전부 `ApiResponse.onSuccess(...)` 컨벤션을 유지했고, Swagger 문서화 및 정렬(createdAt DESC) 고정도 반영했습니다.

## 🛠 작업 내용
- **Controller**
  - `PATCH /api/mypage`
    - 요청: `{ "nickname": string?, "comment": string? }` (둘 중 일부만 수정 가능, null 필드는 무시)
    - 응답: `ApiResponse<MypageUserProfileDto>`
    - Swagger: `@Operation`, `@ApiResponses`, `@Parameter(hidden = true)` 추가
  - `PATCH /api/mypage/profile-image` (consumes=`multipart/form-data`)
    - 요청: `file` 파트(`MultipartFile`) 업로드 → S3 업로드 후 URL을 서비스에 전달하여 프로필 이미지 갱신
    - 비어있는 파일 처리: `FILE_IS_EMPTY` 에러 응답
    - 업로드 실패 처리: `S3_UPLOAD_FAILED` 에러 응답
    - 응답: `ApiResponse<MypageUserProfileDto>`
- **Service**
  - `updateProfile(userId, request)`: 닉네임/코멘트 부분 업데이트
  - `updateProfileImage(userId, fileUrl)`: 업로드된 S3 URL로 사용자 프로필 이미지 갱신
- **DTO (record로 통일)**
  - `MypageUpdateProfileRequest(nickname, comment)`
  - `MypageUserProfileDto(userId, nickname, profileImage, comment)`
  - (`profile-image`는 컨트롤러에서 업로드 + URL 생성 후 서비스에 전달)
- **S3 연동**
  - 컨트롤러에서 `S3Service.uploadFile(file)` 호출 → 반환 URL을 서비스로 전달해 반영
- **정렬 고정**
  - 내가 작성한 게시글/썸네일 조회 로직에 `createdAt DESC` 고정 메서드 사용(예: `findByUserIdOrderByCreatedAtDesc`)
- **Swagger**
  - 마이페이지 엔드포인트에 `@Operation`, `@ApiResponses` 등 문서화 어노테이션 추가