### PR TITLE
✨ [feat] 마이페이지 저정한 게시글 이미지 리스트 조회

### DIFF
--- a/src/main/java/com/vinny/backend/Mypage/Controller/MypageController.java
+++ b/src/main/java/com/vinny/backend/Mypage/Controller/MypageController.java
@@ -134,4 +134,20 @@ public class MypageController {
             );
         }
     }
+
+    @GetMapping("/saved-posts/images")
+    @Operation(
+            summary = "저장한 게시글 첫 이미지 리스트 조회",
+            description = "로그인 사용자가 저장(좋아요)한 게시글에서 각 게시글의 첫 번째 이미지 URL만 추출하여, 좋아요 시점 최신순으로 평평한 리스트로 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "저장한 게시글 첫 이미지 리스트 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    public ResponseEntity<ApiResponse<List<String>>> getSavedPostsFirstImageList(
+            @Parameter(hidden = true) @CurrentUser Long userId
+    ) {
+        List<String> images = mypageService.getSavedPostsFirstImageList(userId);
+        return ResponseEntity.ok(ApiResponse.onSuccess("저장한 게시글의 첫 이미지 리스트를 조회했습니다.", images));
+    }
 }

--- a/src/main/java/com/vinny/backend/Mypage/Service/MypageService.java
+++ b/src/main/java/com/vinny/backend/Mypage/Service/MypageService.java
@@ -132,4 +132,9 @@ public class MypageService {
         user.updateProfileImage(req.imageUrl());
         return toProfileDto(user);
     }
+
+    @Transactional(readOnly = true)
+    public List<String> getSavedPostsFirstImageList(Long userId) {
+        return userPostLikeRepository.findFirstImageUrlsOfLikedPostsOrderByLikedAtDesc(userId);
+    }
 }

--- a/src/main/java/com/vinny/backend/Mypage/dto/MypageSavePostImagesResponse.java
+++ b/src/main/java/com/vinny/backend/Mypage/dto/MypageSavePostImagesResponse.java
@@ -1,0 +1,9 @@
+package com.vinny.backend.Mypage.dto;
+
+import java.util.List;
+
+/** 저장(좋아요)한 게시글별 이미지 목록 */
+public record MypageSavePostImagesResponse(
+        Long postId,
+        List<String> images
+) {}

--- a/src/main/java/com/vinny/backend/post/repository/UserPostLikeRepository.java
+++ b/src/main/java/com/vinny/backend/post/repository/UserPostLikeRepository.java
@@ -4,7 +4,9 @@ import com.vinny.backend.User.domain.User;
 import com.vinny.backend.post.domain.Post;
 import com.vinny.backend.post.domain.mapping.UserPostLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserPostLikeRepository extends JpaRepository<UserPostLike, Long> {
@@ -13,4 +15,19 @@ public interface UserPostLikeRepository extends JpaRepository<UserPostLike, Long
     void deleteByUserAndPost(User user, Post post);
 
     int countByUserId(Long userId);
+
+    @Query("""
+           select pi.imageUrl
+           from UserPostLike upl
+           join upl.post p
+           join p.images pi
+           where upl.user.id = :userId
+             and pi.id.sequence = (
+                 select min(pi2.id.sequence)
+                 from PostImage pi2
+                 where pi2.post = p
+             )
+           order by upl.createdAt desc
+           """)
+    List<String> findFirstImageUrlsOfLikedPostsOrderByLikedAtDesc(Long userId);
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
- close #170 

## 🌱 PR 요약
마이페이지에서 **저장(좋아요)한 게시글들의 첫 번째 이미지 URL만** 추출하여
좋아요 시점 기준 최신순으로 평평한 리스트를 반환하는 API를 구현했습니다.  
엔드포인트: `GET /api/mypage/saved-posts/images`  
응답: `ApiResponse<List<String>>` (예: `["https://.../p3-1.jpg", "https://.../p1-1.jpg"]`)

## 🛠 작업 내용
- **Controller**
  - `GET /api/mypage/saved-posts/images`
    - 인증: `@CurrentUser`  
    - Swagger: `@Operation`, `@ApiResponses`, `@Parameter(hidden = true)` 문서화
    - 응답: `ApiResponse<List<String>>` (각 게시글의 **첫 이미지**만 포함)
- **Service**
  - `getSavedPostsFirstImageList(userId)` 추가
    - 리포지토리에서 첫 이미지 URL들만 받아 그대로 반환
- **Repository**
  - `UserPostLikeRepository#findFirstImageUrlsOfLikedPostsOrderByLikedAtDesc(Long userId)`
    - JPQL 서브쿼리로 **최소 sequence(=첫 이미지)** URL만 조인 추출
    - 정렬: `UserPostLike.createdAt DESC` 고정
- **정렬 정책**
  - 좋아요 시점 최신순 고정(클라이언트 정렬 파라미터 없음)
- **예외/엣지 케이스**
  - 이미지가 없는 게시글은 결과에서 자동 제외

## ❗️리뷰어들께
