### PR TITLE
✨[Feat/#177] 유저 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/vinny/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/vinny/backend/auth/controller/AuthController.java
@@ -108,4 +108,28 @@ public class AuthController {
         SessionResponseDto response = authService.getSession(accessToken);
         return ApiResponse.onSuccess(response);
     }
+
+    @PostMapping("/logout")
+    @Operation(
+            summary = "로그아웃",
+            description = "로그아웃 요청 시, 해당 사용자의 refreshToken을 null로 설정하여 로그아웃 처리합니다."
+    )
+    public ApiResponse<String> logout(HttpServletRequest request) {
+
+        String accessToken = jwtProvider.resolveToken(request);
+
+        if (accessToken == null || !jwtProvider.validateToken(accessToken)) {
+            return ApiResponse.onFailure("Invalid or expired access token.", "로그인 상태가 아닙니다.", null);
+        }
+
+        Long userId = jwtProvider.getUserIdFromToken(accessToken);
+
+        // 로그아웃 처리: 해당 사용자의 refreshToken을 null로 설정
+        try {
+            authService.logout(userId);
+            return ApiResponse.onSuccess("Logout successful.", "로그아웃이 정상적으로 처리되었습니다.");
+        } catch (Exception e) {
+            return ApiResponse.onFailure("Logout Error", "로그아웃 처리 중 오류가 발생했습니다.", null);
+        }
+    }
 }

--- a/src/main/java/com/vinny/backend/auth/service/AuthService.java
+++ b/src/main/java/com/vinny/backend/auth/service/AuthService.java
@@ -155,4 +155,17 @@ public class AuthService {
                     .build();
         }
     }
+
+    @Transactional
+    public void logout(Long userId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // 사용자의 refreshToken을 null로 설정하여 로그아웃 처리
+        user.updateRefreshToken(null);
+
+        // DB에 변경 사항 저장
+        userRepository.save(user);
+    }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #177 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 로그아웃 api 호출 시 refreshToken이 DB에서 삭제됩니다.
- AccessToken은 자동 만료되고 DB에 애초에 저장하지 않기 때문에, 프런트에서 로그아웃 시 삭제처리만 해줍니다.


## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
<img width="2048" height="512" alt="image" src="https://github.com/user-attachments/assets/e6ef66a8-c4f7-4fd2-9b5d-5ced76fb5e73" />
<img width="2048" height="1087" alt="image" src="https://github.com/user-attachments/assets/9ff65749-27e8-45f8-8e84-cb0da5dff35c" />
<img width="2048" height="1074" alt="image" src="https://github.com/user-attachments/assets/334e0537-1b57-4b28-aa3e-280f50cbd206" />
<img width="1960" height="464" alt="image" src="https://github.com/user-attachments/assets/dc6a1d4e-3649-476f-a328-a3698498d043" />




## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
