### PR TITLE
✨ [feat] visitCount 기반 샵랭킹 조회 api 구현

### DIFF
--- a/src/main/java/com/vinny/backend/Shop/controller/ShopController.java
+++ b/src/main/java/com/vinny/backend/Shop/controller/ShopController.java
@@ -1,5 +1,6 @@
 package com.vinny.backend.Shop.controller;
 
+import com.vinny.backend.Shop.domain.Shop;
 import com.vinny.backend.Shop.dto.ShopRequestDto;
 import com.vinny.backend.Shop.dto.ShopResponseDto;
 import com.vinny.backend.Shop.service.ShopCommandService;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api")
@@ -78,6 +80,11 @@ public class ShopController {
     public ResponseEntity<ApiResponse<ShopResponseDto.PreviewDto>> getShopDetails(
             @Parameter(description = "가게 ID", required = true) @PathVariable Long shopId
     ) {
+        Optional<Shop> findedShop = shopService.getShop(shopId);
+        findedShop.ifPresent(shop -> {
+            Integer shopcounts =  shop.getVisitCount();
+            shopcounts = shopcounts + 1;
+        });
         ShopResponseDto.PreviewDto shopDetails = shopService.getShopsDetails(shopId);
         return ResponseEntity.ok(ApiResponse.onSuccess(shopDetails));
     }

--- a/src/main/java/com/vinny/backend/Shop/domain/Shop.java
+++ b/src/main/java/com/vinny/backend/Shop/domain/Shop.java
@@ -57,6 +57,9 @@ public class Shop extends BaseEntity {
     @JoinColumn(name = "region_id")
     private Region region;
 
+    @Column(name = "visit_count")
+    private Integer visitCount;
+
     @Builder.Default
     @OneToMany(mappedBy = "shop", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ShopVintageStyle> shopVintageStyleList = new ArrayList<>();

--- a/src/main/java/com/vinny/backend/Shop/dto/ShopRankingResponse.java
+++ b/src/main/java/com/vinny/backend/Shop/dto/ShopRankingResponse.java
@@ -1,0 +1,15 @@
+// src/main/java/com/vinny/backend/Shop/dto/ShopRankingResponse.java
+package com.vinny.backend.Shop.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "방문수 기준 샵 랭킹 응답")
+public record ShopRankingResponse(
+        @Schema(description = "샵 ID") Long shopId,
+        @Schema(description = "샵 이름") String name,
+        @Schema(description = "주소") String address,
+        @Schema(description = "지역명") String region,
+        @Schema(description = "스타일 태그") List<String> tags,
+        @Schema(description = "대표 이미지 URL") String thumbnailUrl
+) {}

--- a/src/main/java/com/vinny/backend/Shop/dto/ShopResponseDto.java
+++ b/src/main/java/com/vinny/backend/Shop/dto/ShopResponseDto.java
@@ -21,7 +21,6 @@ public class ShopResponseDto {
         private String closeTime;
         private String instagram;
         private String address;
-        private String addressDetail;
         private Double latitude;
         private Double longitude;
         private String region;

--- a/src/main/java/com/vinny/backend/Shop/repository/ShopRankingQueryRepository.java
+++ b/src/main/java/com/vinny/backend/Shop/repository/ShopRankingQueryRepository.java
@@ -1,0 +1,9 @@
+package com.vinny.backend.Shop.repository;
+
+import com.vinny.backend.Shop.domain.Shop;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ShopRankingQueryRepository {
+    Page<Shop> searchRankedByVisit(String regionKeyword, String styleName, Pageable pageable);
+}

--- a/src/main/java/com/vinny/backend/Shop/repository/ShopRankingQueryRepositoryImpl.java
+++ b/src/main/java/com/vinny/backend/Shop/repository/ShopRankingQueryRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.vinny.backend.Shop.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.vinny.backend.Shop.domain.QShop;
+import com.vinny.backend.Shop.domain.QShopImage;
+import com.vinny.backend.Shop.domain.mapping.QShopVintageStyle;
+import com.vinny.backend.Shop.domain.Shop;
+import com.vinny.backend.User.domain.QRegion;
+import com.vinny.backend.User.domain.QVintageStyle;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ShopRankingQueryRepositoryImpl implements ShopRankingQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    private static final QShop s = QShop.shop;
+    private static final QRegion r = QRegion.region;
+    private static final QShopImage img = QShopImage.shopImage;
+    private static final QShopVintageStyle svs = QShopVintageStyle.shopVintageStyle;
+    private static final QVintageStyle vs = QVintageStyle.vintageStyle;
+
+    @Override
+    public Page<Shop> searchRankedByVisit(String regionKeyword, String styleName, Pageable pageable) {
+        // 동적 조건
+        BooleanBuilder where = new BooleanBuilder();
+        if (regionKeyword != null && !regionKeyword.isBlank()) {
+            where.and(r.name.contains(regionKeyword).or(s.address.contains(regionKeyword)));
+        }
+        if (styleName != null && !styleName.isBlank()) {
+            where.and(
+                    JPAExpressions
+                            .selectOne()
+                            .from(svs)
+                            .join(svs.vintageStyle, vs)
+                            .where(svs.shop.eq(s).and(vs.name.eq(styleName)))
+                            .exists()
+            );
+        }
+
+        // 1) ID 페이지 조회 (컬렉션 fetch-join과 페이지네이션 충돌 방지)
+        List<Long> ids = query
+                .select(s.id)
+                .from(s)
+                .leftJoin(s.region, r)
+                .where(where)
+                .orderBy(s.visitCount.coalesce(0).desc(), s.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (ids.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        // 2) 총 개수
+        Long total = query
+                .select(s.id.countDistinct())
+                .from(s)
+                .leftJoin(s.region, r)
+                .where(where)
+                .fetchOne();
+
+        // 3) 상세 로딩 (연관 fetch) + distinct로 중복 제거
+        List<Shop> content = query
+                .selectFrom(s)
+                .leftJoin(s.region, r).fetchJoin()
+                .leftJoin(s.shopVintageStyleList, svs).fetchJoin()
+                .leftJoin(svs.vintageStyle, vs).fetchJoin()
+                .where(s.id.in(ids))
+                .distinct()
+                .fetch();
+
+        // 4) ID 순서대로 정렬 (단순 비교, 별도 Map 사용 안 함)
+        content.sort((a, b) -> Integer.compare(ids.indexOf(a.getId()), ids.indexOf(b.getId())));
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+}

--- a/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
+++ b/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface ShopRepository extends JpaRepository<Shop, Long> {
+public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRankingQueryRepository {
 
     @Query("""
         SELECT DISTINCT s FROM Shop s

--- a/src/main/java/com/vinny/backend/Shop/service/ShopRankingService.java
+++ b/src/main/java/com/vinny/backend/Shop/service/ShopRankingService.java
@@ -1,0 +1,59 @@
+// src/main/java/com/vinny/backend/Shop/service/ShopRankingService.java
+package com.vinny.backend.Shop.service;
+
+import com.vinny.backend.Shop.domain.Shop;
+import com.vinny.backend.Shop.domain.ShopImage;
+import com.vinny.backend.Shop.domain.mapping.ShopVintageStyle;
+import com.vinny.backend.Shop.dto.ShopRankingResponse;
+import com.vinny.backend.Shop.repository.ShopRepository;
+import com.vinny.backend.User.domain.VintageStyle;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShopRankingService {
+
+    private final ShopRepository shopRepository;
+
+    public List<ShopRankingResponse> getRanking(String region, String style, int page, int size) {
+        Page<Shop> pageData = shopRepository.searchRankedByVisit(region, style, PageRequest.of(page, size));
+        return pageData.getContent().stream()
+                .map(this::toShopRankingResponse)
+                .toList();
+    }
+
+    /** Shop -> ShopRankingResponse 변환 전용 컨버터 */
+    private ShopRankingResponse toShopRankingResponse(Shop s) {
+        String regionName = (s.getRegion() != null) ? s.getRegion().getName() : null;
+
+        List<String> tags = s.getShopVintageStyleList().stream()
+                .map(ShopVintageStyle::getVintageStyle)
+                .filter(Objects::nonNull)
+                .map(VintageStyle::getName)
+                .toList();
+
+        String thumbnailUrl = s.getShopImages().stream()
+                .sorted(Comparator.comparing(ShopImage::isMainImage).reversed()) // 메인 이미지 우선
+                .map(ShopImage::getImageUrl)
+                .findFirst()
+                .orElse(null);
+
+        return new ShopRankingResponse(
+                s.getId(),
+                s.getName(),
+                s.getAddress(),
+                regionName,
+                tags,
+                thumbnailUrl
+        );
+    }
+}

--- a/src/main/java/com/vinny/backend/Shop/service/ShopService.java
+++ b/src/main/java/com/vinny/backend/Shop/service/ShopService.java
@@ -56,4 +56,12 @@ public class ShopService {
         return shopConverter.toMapThumbnailDto(shop);
     }
 
+    public Optional<Shop> getShop(long shopId) {
+        Shop shop = shopRepository.findById(shopId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
+        return Optional.of(shop);
+    }
+
+
 }
+

--- a/src/main/java/com/vinny/backend/User/domain/mapping/UserShop.java
+++ b/src/main/java/com/vinny/backend/User/domain/mapping/UserShop.java
@@ -33,15 +33,13 @@ public class UserShop extends BaseEntity {
     @Column(name = "status")
     private UserShopStatus status;
 
-    @Column(name = "visit_count")
-    private Integer visitCount;
+
 
     public static UserShop create(User user, Shop shop, UserShopStatus status, Integer visitCount) {
         return UserShop.builder()
                 .user(user)
                 .shop(shop)
                 .status(status)
-                .visitCount(visitCount)
                 .build();
     }
 
@@ -50,7 +48,6 @@ public class UserShop extends BaseEntity {
                 .user(user)
                 .shop(shop)
                 .status(status)
-                .visitCount(0) // 기본값 설정
                 .build();
     }
 

--- a/src/main/java/com/vinny/backend/User/dto/UserShopResponseDto.java
+++ b/src/main/java/com/vinny/backend/User/dto/UserShopResponseDto.java
@@ -31,7 +31,6 @@ public class UserShopResponseDto {
                 .userId(userShop.getUser().getId())
                 .shopId(userShop.getShop().getId())
                 .status(userShop.getStatus())
-                .visitCount(userShop.getVisitCount())
                 .build();
     }
 

--- a/src/main/java/com/vinny/backend/config/SecurityConfig.java
+++ b/src/main/java/com/vinny/backend/config/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
                                 "/files/**",
                                 "/api/map/shops/all",
                                 "/health",
-                                "/api/auth/session").permitAll() // 로그인 및 H2 콘솔 경로는 모두 허용, 배포 시점에 추후 수정 예정
+                                "/api/auth/session",
+                                "/api/shops/ranking").permitAll() // 로그인 및 H2 콘솔 경로는 모두 허용, 배포 시점에 추후 수정 예정
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Feat/#{이슈번호}] 방문수 기반 샵 랭킹 API(QueryDSL) 구현 -->
<!-- 리뷰어와 라벨을 꼭 적용해 주세요! -->

## 📌 연관 이슈
- close #199 
## 🌱 PR 요약
방문수(`visitCount`) 기준으로 샵을 정렬해 반환하는 **랭킹 API**를 QueryDSL로 구현했습니다.  
지역(홍대/성수/강남 등)과 빈티지 스타일(밀리터리/아메카지 등) **선택적 필터링**을 지원하며,  
응답 DTO는 `record` 기반으로 작성했습니다.  
`MultipleBagFetchException`은 한 컬렉션만 fetch-join하고 나머지는 **배치 페치**로 해결했습니다.

## 🛠 작업 내용
- **QueryDSL 기반 검색 조건 구현**
  - `regionKeyword` → 지역명 / 주소에 부분 일치 검색
  - `styleName` → 해당 빈티지 스타일 보유 샵 필터링
- **방문수 기준 내림차순 정렬**
- **페이징 처리**
  - ID 조회 → 상세 조회 방식으로 페이징 & fetch-join 충돌 방지
- **DTO 변환**
  - `ShopRankingResponse` record 사용
  - 메인 이미지 우선 반환
  - 빈티지 스타일명 리스트 반환

## ❗️리뷰어들께
