### PR TITLE
🐛 [Fix/#213] Map Api Response 대표스타일 추가

### DIFF
--- a/src/main/java/com/vinny/backend/Shop/domain/Shop.java
+++ b/src/main/java/com/vinny/backend/Shop/domain/Shop.java
@@ -2,6 +2,7 @@ package com.vinny.backend.Shop.domain;
 
 import com.vinny.backend.Shop.domain.mapping.ShopVintageStyle;
 import com.vinny.backend.User.domain.Region;
+import com.vinny.backend.User.domain.VintageStyle;
 import com.vinny.backend.common.domain.BaseEntity;
 import com.vinny.backend.Shop.domain.enums.Status;
 import jakarta.persistence.*;
@@ -59,6 +60,10 @@ public class Shop extends BaseEntity {
 
     @Column(name = "visit_count")
     private Integer visitCount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "main_vintage_style_id")
+    private VintageStyle mainVintageStyle;
 
     @Builder.Default
     @OneToMany(mappedBy = "shop", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/vinny/backend/map/converter/MapConverter.java
+++ b/src/main/java/com/vinny/backend/map/converter/MapConverter.java
@@ -2,6 +2,7 @@ package com.vinny.backend.map.converter;
 
 import com.vinny.backend.Shop.domain.Shop;
 import com.vinny.backend.Shop.domain.mapping.ShopVintageStyle;
+import com.vinny.backend.User.domain.VintageStyle;
 import com.vinny.backend.map.dto.MapResponseDto.VintageStyleDto;
 import com.vinny.backend.map.dto.MapResponseDto.MapListDto;
 import org.springframework.stereotype.Component;
@@ -24,6 +25,7 @@ public class MapConverter {
                 .latitude(shop.getLatitude())
                 .longitude(shop.getLongitude())
                 .vintageStyleList(toVintageStyleDtos(shop.getShopVintageStyleList()))
+                .mainVintageStyle(toMainVintageStyleDto(shop.getMainVintageStyle())) // 👈 이 줄을 추가해야 합니다.
                 .build();
     }
 
@@ -34,5 +36,17 @@ public class MapConverter {
                         .vintageStyleName(mapping.getVintageStyle().getName())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    private VintageStyleDto toMainVintageStyleDto(VintageStyle mainStyle) {
+        // 대표 스타일이 없는 경우(null)를 안전하게 처리
+        if (mainStyle == null) {
+            return null;
+        }
+        // 엔티티를 DTO로 변환
+        return VintageStyleDto.builder()
+                .id(mainStyle.getId())
+                .vintageStyleName(mainStyle.getName())
+                .build();
     }
 }

--- a/src/main/java/com/vinny/backend/map/converter/MapConverter.java
+++ b/src/main/java/com/vinny/backend/map/converter/MapConverter.java
@@ -25,7 +25,7 @@ public class MapConverter {
                 .latitude(shop.getLatitude())
                 .longitude(shop.getLongitude())
                 .vintageStyleList(toVintageStyleDtos(shop.getShopVintageStyleList()))
-                .mainVintageStyle(toMainVintageStyleDto(shop.getMainVintageStyle())) // 👈 이 줄을 추가해야 합니다.
+                .mainVintageStyle(toMainVintageStyleDto(shop.getMainVintageStyle()))
                 .build();
     }
 
@@ -39,11 +39,9 @@ public class MapConverter {
     }
 
     private VintageStyleDto toMainVintageStyleDto(VintageStyle mainStyle) {
-        // 대표 스타일이 없는 경우(null)를 안전하게 처리
         if (mainStyle == null) {
             return null;
         }
-        // 엔티티를 DTO로 변환
         return VintageStyleDto.builder()
                 .id(mainStyle.getId())
                 .vintageStyleName(mainStyle.getName())

--- a/src/main/java/com/vinny/backend/map/dto/MapResponseDto.java
+++ b/src/main/java/com/vinny/backend/map/dto/MapResponseDto.java
@@ -1,6 +1,7 @@
 package com.vinny.backend.map.dto;
 
 import com.vinny.backend.Shop.domain.mapping.ShopVintageStyle;
+import com.vinny.backend.User.domain.VintageStyle;
 import lombok.*;
 
 import java.util.List;
@@ -19,6 +20,7 @@ public class MapResponseDto {
         private Double latitude;
         private Double longitude;
         private List<VintageStyleDto> vintageStyleList;
+        private VintageStyleDto mainVintageStyle;
     }
 
     @Getter


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #213 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- Map API 에서 사용되는 MapResponseDto에서 각 샵의 대표 스타일을 추가했습니다.
- Shop 테이블에 main_vintage_style_id를 추가했습니다.
- 응답에 전체 스타일 불러오는 건 삭제할까 생각했지만 추후 지도에서 필터링 기능이 생기면 필요하기 때문에 그대로 놔두고 대표 스타일만 따로 추가했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
<img width="1270" height="752" alt="image" src="https://github.com/user-attachments/assets/f58f0205-f322-4ab7-ac5e-45196d71d28d" />


## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
