### PR TITLE
♻️ [refactor] 가게 자동완성에 주소 추가

### DIFF
--- a/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
+++ b/src/main/java/com/vinny/backend/Shop/repository/ShopRepository.java
@@ -9,7 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRankingQueryRepository {
 
@@ -56,5 +58,8 @@ public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRankingQu
     @Query("select s.name from Shop s")
     List<String> findAllShopNames();
 
+    List<Shop> findByNameIn(List<String> names);
 
+
+    Optional<List<Object>> findShopByNameIn(Collection<String> names);
 }

--- a/src/main/java/com/vinny/backend/Shop/service/ShopService.java
+++ b/src/main/java/com/vinny/backend/Shop/service/ShopService.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -84,6 +85,11 @@ public class ShopService {
         return getShopsDetails(shopId, userId); // 기존 DTO 생성 로직 재사용
     }
 
-
+    public List<Shop> getShopByName(List<String> names) {
+        if (names == null || names.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return shopRepository.findByNameIn(names);
+    }
 }
 

--- a/src/main/java/com/vinny/backend/search/controller/AutocompleteController.java
+++ b/src/main/java/com/vinny/backend/search/controller/AutocompleteController.java
@@ -1,7 +1,10 @@
 package com.vinny.backend.search.controller;
 
+import com.vinny.backend.Shop.domain.Shop;
+import com.vinny.backend.Shop.service.ShopService;
 import com.vinny.backend.error.ApiResponse;
 import com.vinny.backend.search.annotation.CurrentUser;
+import com.vinny.backend.search.dto.AutocompleteShopResponse;
 import com.vinny.backend.search.service.AutocompleteSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,6 +21,7 @@ import java.util.List;
 public class AutocompleteController {
 
     private final AutocompleteSearchService autocompleteSearchService;
+    private final ShopService shopService;
 
     @GetMapping("/brands")
     @Operation(
@@ -47,12 +51,25 @@ public class AutocompleteController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "자동완성 결과 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (keyword 파라미터가 누락 등)")
     })
-    public ResponseEntity<ApiResponse<List<String>>> shopAutocomplete(
+    public ResponseEntity<ApiResponse<List<AutocompleteShopResponse>>> shopAutocomplete(
             @Parameter(hidden = true) @CurrentUser Long userId,
             @Parameter(description = "자동완성에 사용할 키워드", example = "발발빈티지", required = true)
             @RequestParam String keyword
     ) {
-        List<String> result = autocompleteSearchService.autocompleteShopName(keyword);
-        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+        List<String> names = autocompleteSearchService.autocompleteShopName(keyword);
+
+        // shop 엔티티 목록 조회
+        List<Shop> shops = shopService.getShopByName(names);
+
+        // DTO 변환
+        List<AutocompleteShopResponse> response = shops.stream()
+                .map(shop -> new AutocompleteShopResponse(
+                        shop.getName(),
+                        shop.getLogoImage(),
+                        shop.getAddress()// 엔티티에 logo 필드 있다고 가정
+                ))
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/vinny/backend/search/dto/AutocompleteShopResponse.java
+++ b/src/main/java/com/vinny/backend/search/dto/AutocompleteShopResponse.java
@@ -1,0 +1,7 @@
+package com.vinny.backend.search.dto;
+
+public record AutocompleteShopResponse(
+        String name,
+        String imageUrl,
+        String address
+) {}


### PR DESCRIPTION
# ♻️ [refactor] 가게 자동완성에 주소 추가

## 📌 연관 이슈
- close #226 

## 🌱 PR 요약
- 가게 자동완성 API 응답에 주소 필드를 추가

## 🛠 작업 내용
- `AutocompleteShopResponse` DTO에 `address` 필드 추가
- `shopAutocomplete` API에서 Shop 엔티티의 주소 값을 함께 반환하도록 수정

## ❗️리뷰어들께
- 기존 자동완성 응답(JSON) 구조가 바뀌므로 프론트엔드와 연동 시 주의 부탁드립니다.
