### PR TITLE
[Feat/#251] 유저 온보딩 reset시 홈 취향저격 리스트 즉시 반영

### DIFF
--- a/src/main/java/com/vinny/backend/User/config/AsyncConfig.java
+++ b/src/main/java/com/vinny/backend/User/config/AsyncConfig.java
@@ -1,0 +1,8 @@
+package com.vinny.backend.User.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {}

--- a/src/main/java/com/vinny/backend/User/config/UserPreferenceChangedEvent.java
+++ b/src/main/java/com/vinny/backend/User/config/UserPreferenceChangedEvent.java
@@ -1,0 +1,6 @@
+package com.vinny.backend.User.config;
+
+
+
+public record UserPreferenceChangedEvent(Long userId) {}
+

--- a/src/main/java/com/vinny/backend/User/config/WeeklyRegenListener.java
+++ b/src/main/java/com/vinny/backend/User/config/WeeklyRegenListener.java
@@ -1,0 +1,23 @@
+package com.vinny.backend.User.config;
+
+import com.vinny.backend.User.service.UserShopForYouService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+@Component
+@RequiredArgsConstructor
+public class WeeklyRegenListener {
+
+    private final UserShopForYouService userShopForYouService;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(UserPreferenceChangedEvent event) {
+        userShopForYouService.regenerateThisWeek(event.userId());
+    }
+}

--- a/src/main/java/com/vinny/backend/User/controller/UserShopForYouController.java
+++ b/src/main/java/com/vinny/backend/User/controller/UserShopForYouController.java
@@ -31,7 +31,7 @@ public class UserShopForYouController {
 
     @Operation(
             summary = "홈 취향저격 가게 추천",
-            description = "홈 취향저격 가게 추천 목록을 조회합니다. 저장된 데이터가 없으면 생성 후 반환합니다."
+            description = "홈 취향저격 가게 추천 목록을 조회합니다. 매 조회시 생성된 리스트 중 랜덤으로 3개를 반환합니다. "
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -46,7 +46,6 @@ public class UserShopForYouController {
             )
     })
     @Parameters({
-            @Parameter(name = "limit", description = "반환 개수"),
             @Parameter(name = "userId", hidden = true)
     })
     @GetMapping

--- a/src/main/java/com/vinny/backend/User/repository/UserShopForYouRepository.java
+++ b/src/main/java/com/vinny/backend/User/repository/UserShopForYouRepository.java
@@ -11,4 +11,7 @@ public interface UserShopForYouRepository extends JpaRepository<UserWeeklyShop, 
     List<UserWeeklyShop> findByUser_IdAndWeekStart(Long userId, LocalDate weekStart);
 
     void deleteByUser_IdAndWeekStartLessThan(Long userId, LocalDate weekStart);
+
+    boolean existsByUser_IdAndWeekStartAndShop_Id(Long userId, LocalDate weekStart, Long shopId);
+
 }

--- a/src/main/java/com/vinny/backend/User/service/UserService.java
+++ b/src/main/java/com/vinny/backend/User/service/UserService.java
@@ -4,13 +4,15 @@ import com.vinny.backend.User.domain.*;
 import com.vinny.backend.User.domain.enums.UserStatus;
 import com.vinny.backend.User.domain.mapping.*;
 import com.vinny.backend.User.dto.*;
+import com.vinny.backend.User.config.UserPreferenceChangedEvent;
 import com.vinny.backend.User.repository.*;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,61 +23,66 @@ public class UserService {
     private final BrandRepository brandRepository;
     private final VintageItemRepository vintageItemRepository;
     private final RegionRepository regionRepository;
+    private final UserShopForYouService userShopForYouService;
+    private final EntityManager em;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional
     public void completeOnboarding(Long userId, OnboardingRequestDto requestDto) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("온보딩 진행 중인 사용자를 찾을 수 없습니다."));
 
-        // 1. 닉네임 업데이트 및 상태를 'ACTIVE'로 변경
+        // 1. 닉네임/코멘트/상태
         user.updateNickname(requestDto.getNickname());
         user.updateComment(requestDto.getComment());
         user.changeStatus(UserStatus.ACTIVE);
 
-        // 2. VintageStyle 정보 저장
+        // 2. VintageStyle
         if (requestDto.getVintageStyleIds() != null && !requestDto.getVintageStyleIds().isEmpty()) {
             List<VintageStyle> vintageStyles = vintageStyleRepository.findAllById(requestDto.getVintageStyleIds());
             List<UserVintageStyle> userVintageStyles = vintageStyles.stream()
                     .map(style -> UserVintageStyle.builder().user(user).vintageStyle(style).build())
-                    .collect(Collectors.toList());
-            user.getUserVintageStyleList().clear(); // 기존 정보가 있다면 초기화
+                    .toList();
+            user.getUserVintageStyleList().clear();
             user.getUserVintageStyleList().addAll(userVintageStyles);
         }
 
-        // 3. Brand 정보 저장
+        // 3. Brand
         if (requestDto.getBrandIds() != null && !requestDto.getBrandIds().isEmpty()) {
             List<Brand> brands = brandRepository.findAllById(requestDto.getBrandIds());
             List<UserBrand> userBrands = brands.stream()
                     .map(brand -> UserBrand.builder().user(user).brand(brand).build())
-                    .collect(Collectors.toList());
+                    .toList();
             user.getUserBrandList().clear();
             user.getUserBrandList().addAll(userBrands);
         }
 
-        // 4. VintageItem 정보 저장 (위와 동일한 패턴)
+        // 4. VintageItem
         if (requestDto.getVintageItemIds() != null && !requestDto.getVintageItemIds().isEmpty()) {
             List<VintageItem> vintageItems = vintageItemRepository.findAllById(requestDto.getVintageItemIds());
             List<UserVintageItem> userVintageItems = vintageItems.stream()
                     .map(item -> UserVintageItem.builder().user(user).vintageItem(item).build())
-                    .collect(Collectors.toList());
+                    .toList();
             user.getUserVintageItemList().clear();
             user.getUserVintageItemList().addAll(userVintageItems);
         }
 
-        // 5. Region 정보 저장 (위와 동일한 패턴)
+        // 5. Region
         if (requestDto.getRegionIds() != null && !requestDto.getRegionIds().isEmpty()) {
             List<Region> regions = regionRepository.findAllById(requestDto.getRegionIds());
             List<UserRegion> userRegions = regions.stream()
                     .map(region -> UserRegion.builder().user(user).region(region).build())
-                    .collect(Collectors.toList());
+                    .toList();
             user.getUserRegionList().clear();
             user.getUserRegionList().addAll(userRegions);
         }
+
+        em.flush(); // 중요: 변경을 DB에 밀어넣음
+        publisher.publishEvent(new UserPreferenceChangedEvent(userId));
     }
 
     @Transactional
     public void resetVintageStyle(Long userId, UserVintageStyleRequestDto requestDto) {
-
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("취향 재설정 중인 사용자를 찾을 수 없습니다."));
 
@@ -83,15 +90,17 @@ public class UserService {
             List<VintageStyle> vintageStyles = vintageStyleRepository.findAllById(requestDto.getVintageStyleIds());
             List<UserVintageStyle> userVintageStyles = vintageStyles.stream()
                     .map(style -> UserVintageStyle.builder().user(user).vintageStyle(style).build())
-                    .collect(Collectors.toList());
-            user.getUserVintageStyleList().clear(); // 기존 정보가 있다면 초기화
+                    .toList();
+            user.getUserVintageStyleList().clear();
             user.getUserVintageStyleList().addAll(userVintageStyles);
         }
+
+        em.flush();
+        publisher.publishEvent(new UserPreferenceChangedEvent(userId));
     }
 
     @Transactional
     public void resetBrand(Long userId, UserBrandRequestDto requestDto) {
-
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("취향 재설정 중인 사용자를 찾을 수 없습니다."));
 
@@ -99,15 +108,17 @@ public class UserService {
             List<Brand> brands = brandRepository.findAllById(requestDto.getBrandIds());
             List<UserBrand> userBrands = brands.stream()
                     .map(brand -> UserBrand.builder().user(user).brand(brand).build())
-                    .collect(Collectors.toList());
+                    .toList();
             user.getUserBrandList().clear();
             user.getUserBrandList().addAll(userBrands);
         }
+
+        em.flush();
+        publisher.publishEvent(new UserPreferenceChangedEvent(userId));
     }
 
     @Transactional
     public void resetVintageItem(Long userId, UserVintageItemRequestDto requestDto) {
-
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("취향 재설정 중인 사용자를 찾을 수 없습니다."));
 
@@ -115,15 +126,17 @@ public class UserService {
             List<VintageItem> vintageItems = vintageItemRepository.findAllById(requestDto.getVintageItemIds());
             List<UserVintageItem> userVintageItems = vintageItems.stream()
                     .map(item -> UserVintageItem.builder().user(user).vintageItem(item).build())
-                    .collect(Collectors.toList());
+                    .toList();
             user.getUserVintageItemList().clear();
             user.getUserVintageItemList().addAll(userVintageItems);
         }
+
+        em.flush();
+        publisher.publishEvent(new UserPreferenceChangedEvent(userId));
     }
 
     @Transactional
     public void resetRegion(Long userId, UserRegionRequestDto requestDto) {
-
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("취향 재설정 중인 사용자를 찾을 수 없습니다."));
 
@@ -131,9 +144,14 @@ public class UserService {
             List<Region> regions = regionRepository.findAllById(requestDto.getRegionIds());
             List<UserRegion> userRegions = regions.stream()
                     .map(region -> UserRegion.builder().user(user).region(region).build())
-                    .collect(Collectors.toList());
+                    .toList();
             user.getUserRegionList().clear();
             user.getUserRegionList().addAll(userRegions);
         }
+
+
+        em.flush();
+        publisher.publishEvent(new UserPreferenceChangedEvent(userId));
+
     }
 }

--- a/src/main/java/com/vinny/backend/User/service/UserShopForYouService.java
+++ b/src/main/java/com/vinny/backend/User/service/UserShopForYouService.java
@@ -12,6 +12,7 @@ import com.vinny.backend.User.repository.UserShopForYouRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
@@ -19,6 +20,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.temporal.TemporalAdjusters;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
@@ -39,35 +41,35 @@ public class UserShopForYouService {
      */
     @Transactional
     public List<ShopResponseDto.HomeForYouThumbnailDto> getThisWeekForYou(Long userId) {
-        // 지난 주 이전 데이터 정리만 수행 (이번 주는 건드리지 않음)
+        // 지난 주 이전 데이터 정리만 수행
         deleteOldWeeklyShops(userId);
 
         LocalDate weekStart = getCurrentWeekStart();
 
-        // 이번 주 데이터 있으면 그대로 반환
+        // 이번 주 데이터 조회(없으면 생성)
         List<UserWeeklyShop> saved = weeklyRepo.findByUser_IdAndWeekStart(userId, weekStart);
         if (saved == null || saved.isEmpty()) {
-            // 없을 때만 생성 (현재 주 삭제 없음)
             saved = generateAndPersistWeekly(userId, weekStart);
         }
 
-        List<Long> idsInOrder = saved.stream()
-                .map(uws -> uws.getShop().getId())
+        // 저장된 후보에서 매 호출마다 랜덤 샘플 3개
+        List<Shop> shops = saved.stream()
+                .map(UserWeeklyShop::getShop)
                 .filter(Objects::nonNull)
                 .toList();
-        if (idsInOrder.isEmpty()) return List.of();
 
-        Map<Long,Integer> order = new HashMap<>();
-        for (int i = 0; i < idsInOrder.size(); i++) order.put(idsInOrder.get(i), i);
+        if (shops.isEmpty()) return List.of();
 
-        List<Shop> shops = shopRepository.findAllById(idsInOrder);
+        // 섞을 수 있도록 변경 가능한 리스트로 만들기
+        List<Shop> shuffled = new ArrayList<>(shops);
+        Collections.shuffle(shuffled, ThreadLocalRandom.current());
 
-        return shops.stream()
-                .sorted(Comparator.comparingInt(s -> order.getOrDefault(s.getId(), Integer.MAX_VALUE)))
+        return shuffled.stream()
+                .limit(DEFAULT_LIMIT) // 최대 3개
                 .map(shopConverter::toHomeForYouThumbnailDto)
-                .limit(DEFAULT_LIMIT)
                 .toList();
     }
+
 
 
     /**
@@ -77,8 +79,9 @@ public class UserShopForYouService {
     public List<ShopResponseDto.HomeForYouThumbnailDto> regenerateThisWeek(Long userId) {
         LocalDate weekStart = getCurrentWeekStart();
 
-        // 이번 주 데이터만 지우고 재생성
         weeklyRepo.deleteByUser_IdAndWeekStart(userId, weekStart);
+        em.flush();
+
         List<UserWeeklyShop> saved = generateAndPersistWeekly(userId, weekStart);
 
         List<Long> shopIdsInOrder = saved.stream()
@@ -116,16 +119,31 @@ public class UserShopForYouService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
 
-        List<Long> matchedIds = new ArrayList<>(shopQueryRepository.findMatchedShopIdsRandomByUser(userId));
-        if (matchedIds.size() > DEFAULT_LIMIT) {
-            matchedIds = matchedIds.subList(0, DEFAULT_LIMIT);
+        // 1) 후보 조회
+        List<Long> rawIds = new ArrayList<>(shopQueryRepository.findMatchedShopIdsRandomByUser(userId));
+
+        // 2) null 제거 + 중복 제거(순서 유지)
+        LinkedHashSet<Long> dedup = new LinkedHashSet<>();
+        for (Long id : rawIds) {
+            if (id != null) dedup.add(id);
         }
+
+        // 3) limit 적용 (중복 제거 후 적용해야 함)
+        List<Long> matchedIds = dedup.stream()
+                .limit(DEFAULT_LIMIT)
+                .toList();
+
         if (matchedIds.isEmpty()) return List.of();
 
         List<UserWeeklyShop> saved = new ArrayList<>(matchedIds.size());
+
         for (Long shopId : matchedIds) {
             Shop shop = shopRepository.findById(shopId).orElse(null);
             if (shop == null) continue;
+
+            // 4) 혹시 남아있는 동일 row가 있다면 방어적으로 skip
+            boolean exists = weeklyRepo.existsByUser_IdAndWeekStartAndShop_Id(userId, weekStart, shopId);
+            if (exists) continue;
 
             saved.add(weeklyRepo.save(
                     UserWeeklyShop.builder()
@@ -135,6 +153,7 @@ public class UserShopForYouService {
                             .build()
             ));
         }
+
         em.flush();
         return saved;
     }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #251

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
 사용자가 온보딩 과정에서 취향을 재설정할 경우, '취향저격 가게' 추천 목록이 지연 없이 즉시 새로운 취향에 맞춰 재생성되도록 시스템을 개선했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
  1. 비동기 이벤트 기반 아키텍처 도입
   - 목적: 사용자의 취향 정보가 변경되는 트랜잭션과 추천 목록을 재생성하는 로직을 분리하여, 사용자 요청에 대한 응답 지연을 없애고 시스템의 반응성을 높였습니다.
   - 구현:
       - UserPreferenceChangedEvent 라는 이벤트를 정의했습니다.
       - 사용자의 취향이 변경되는 UserService의 메서드(completeOnboarding, resetVintageStyle 등)가 실행되고 데이터베이스에 성공적으로 반영(commit)된 후, 위 이벤트를 발행하도록
         구현했습니다.
       - WeeklyRegenListener가 해당 이벤트를 비동기적으로 구독하여, 별도의 트랜잭션에서 UserShopForYouService.regenerateThisWeek() 메서드를 호출함으로써 추천 목록을 재생성합니다.

  2. 추천 목록 생성 로직 개선                                                                                                                                                         
   - `UserShopForYouService` 수정:                                                                                                                                                    
       - 랜덤 추천: 기존에는 매번 동일한 순서의 추천 가게 목록을 반환했지만, 이제는 생성된 후보 목록 내에서 매번 랜덤하게 3개의 가게를 반환하도록 로직을 변경했습니다.                
       - 중복 제거 및 안정성 강화: 추천 후보 가게 ID를 가져올 때 중복을 제거하는 로직을 추가하고, 데이터베이스에 저장하기 전 이미 존재하는 데이터인지 확인하는 방어 코드를 추가하여   
         데이터 정합성을 높였습니다.                                                                                                                                                  
                                                                                                                                                                                      
  3. API 문서 업데이트                                                                                                                                                                
   - UserShopForYouController의 API 명세(@Operation) 설명을 변경된 랜덤 반환 정책에 맞게 수정하여, API 사용자가 최신 정보를 확인할 수 있도록 했습니다.   
## ❗️리뷰어들께
<!-- 리뷰어가 특별히 봐야할 부분이나 주의할 점을 적어주세요 -->
